### PR TITLE
Add OCA as author of OCA addons

### DIFF
--- a/hw_customer_display/__openerp__.py
+++ b/hw_customer_display/__openerp__.py
@@ -75,7 +75,7 @@ Association !
 This module has been written by Alexis de Lattre from Akretion
 <alexis.delattre@akretion.com>.
     """,
-    'author': 'Akretion',
+    'author': "Akretion,Odoo Community Association (OCA)",
     'website': 'http://www.akretion.com',
     'depends': ['hw_proxy'],
     'external_dependencies': {

--- a/hw_telium_payment_terminal/__openerp__.py
+++ b/hw_telium_payment_terminal/__openerp__.py
@@ -73,7 +73,7 @@ Association !
 This module has been written by Alexis de Lattre
 <alexis.delattre@akretion.com> from Akretion.
     """,
-    'author': 'Akretion',
+    'author': "Akretion,Odoo Community Association (OCA)",
     'website': 'http://www.akretion.com',
     'depends': ['hw_proxy'],
     'external_dependencies': {

--- a/pos_customer_display/__openerp__.py
+++ b/pos_customer_display/__openerp__.py
@@ -48,7 +48,7 @@ project of the Odoo Community Association http://odoo-community.org/.
 You are invited to become a member and/or get involved in the
 Association !
     """,
-    'author': 'Aurélien DUMAINE',
+    'author': "Aurélien DUMAINE,Odoo Community Association (OCA)",
     'license': 'AGPL-3',
     'depends': ['point_of_sale'],
     'data': [

--- a/pos_payment_terminal/__openerp__.py
+++ b/pos_payment_terminal/__openerp__.py
@@ -46,7 +46,7 @@ project of the Odoo Community Association http://odoo-community.org/.
 You are invited to become a member and/or get involved in the
 Association !
     """,
-    'author': 'Aurélien DUMAINE',
+    'author': "Aurélien DUMAINE,Odoo Community Association (OCA)",
     'license': 'AGPL-3',
     'depends': ['point_of_sale'],
     'data': [

--- a/pos_pricelist/__openerp__.py
+++ b/pos_pricelist/__openerp__.py
@@ -21,7 +21,7 @@
     'version': '1.0.0',
     'category': 'Point Of Sale',
     'sequence': 1,
-    'author': 'Adil Houmadi @Taktik',
+    'author': "Adil Houmadi @Taktik,Odoo Community Association (OCA)",
     'summary': 'Pricelist for Point of sale',
     'description': """
 New feature for the Point Of Sale:

--- a/pos_product_template/__openerp__.py
+++ b/pos_product_template/__openerp__.py
@@ -55,7 +55,7 @@ Copyright, Authors and Licence:
     * Author:
         * Sylvain LE GAL (https://twitter.com/legalsylvain);
     * Licence: AGPL-3 (http://www.gnu.org/licenses/);""",
-    'author': 'Akretion',
+    'author': "Akretion,Odoo Community Association (OCA)",
     'website': 'http://www.akretion.com',
     'license': 'AGPL-3',
     'depends': [


### PR DESCRIPTION
In order to get visibility on https://www.odoo.com/apps the OCA board has
decided to add the OCA as author of all the addons maintained as part of the
association.
