### PR TITLE
[FIX] : Fix omitted instruction on taxes_ids

### DIFF
--- a/pos_pricelist/static/src/js/models.js
+++ b/pos_pricelist/static/src/js/models.js
@@ -189,7 +189,7 @@ function pos_pricelist_models(instance, module) {
                 }
             }
             if (product_taxes.length === 0) {
-                for (var i = 0, ilen = product.taxes_id; i < ilen; i++) {
+                for (var i = 0, ilen = product.taxes_id.length; i < ilen; i++) {
                     var _id = product.taxes_id[i];
                     var p_tax = _.detect(this.pos.taxes, function (t) {
                         return t.id === _id;


### PR DESCRIPTION
Issue reported via mail by : 
- Arjan Rosman

```
Nice module. Just what we are looking for as a part of creating an offline order possibility,
The only thing is that it does not work if with VAT. 
We are using Odoo 8, dutch localisation. It only appears when we have VAT Applied on the products. Is this a (known) issue or is this just in our test instances a problem.

Odoo Cliënt fout
Uncaught TypeError: Cannot read property 'price_include' of undefined

I do not know were to place this question. So I send it directly to you. My apologies if this is not the right way.
```
- NG ChiaHow

```
First of all, I would like to thank you for this wonderful App.
I just found an issue with pos_pricelist App.
Where there is a customer tax set for the product, when I select the product in POS, I get the error as attached.
Are you aware of this, or this has been rectified?
Hope to hear from you soon.
via apps.odoo.com
```
