### PR TITLE
pos_customer_display: Add button "Display Total to Customer" + port to new API

### DIFF
--- a/pos_customer_display/__openerp__.py
+++ b/pos_customer_display/__openerp__.py
@@ -48,11 +48,13 @@ project of the Odoo Community Association http://odoo-community.org/.
 You are invited to become a member and/or get involved in the
 Association !
     """,
-    'author': "Aurélien DUMAINE,Odoo Community Association (OCA)",
+    'author': "Aurélien DUMAINE,Akretion,Odoo Community Association (OCA)",
     'license': 'AGPL-3',
     'depends': ['point_of_sale'],
     'data': [
         'pos_customer_display.xml',
         'customer_display_view.xml',
         ],
+    'qweb': ['static/src/xml/pos.xml'],
+    'demo': ['pos_customer_display_demo.xml'],
 }

--- a/pos_customer_display/i18n/fr.po
+++ b/pos_customer_display/i18n/fr.po
@@ -6,9 +6,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-10-24 13:45+0000\n"
-"PO-Revision-Date: 2014-10-24 13:45+0000\n"
-"Last-Translator: <>\n"
+"POT-Creation-Date: 2015-05-16 23:24+0000\n"
+"PO-Revision-Date: 2015-05-16 23:24+0000\n"
+"Last-Translator: Alexis de Lattre <alexis.delattre@akretion.com>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,22 +17,29 @@ msgstr ""
 
 #. module: pos_customer_display
 #. openerp-web
-#: code:addons/pos_customer_display/static/src/js/customer_display.js:56
+#: code:addons/pos_customer_display/static/src/js/customer_display.js:58
 #, python-format
 msgid "Cancel Payment"
 msgstr "Paiement annulé"
 
 #. module: pos_customer_display
 #: field:pos.config,iface_customer_display:0
-msgid "Customer display"
+msgid "Customer Display"
 msgstr "Afficheur client"
 
 #. module: pos_customer_display
 #. openerp-web
-#: code:addons/pos_customer_display/static/src/js/customer_display.js:41
+#: code:addons/pos_customer_display/static/src/js/customer_display.js:42
 #, python-format
 msgid "Delete Item"
 msgstr "Article supprimé"
+
+#. module: pos_customer_display
+#. openerp-web
+#: code:addons/pos_customer_display/static/src/xml/pos.xml:7
+#, python-format
+msgid "Display Total to Customer"
+msgstr "Afficher le total au client"
 
 #. module: pos_customer_display
 #: help:pos.config,iface_customer_display:0
@@ -46,40 +53,40 @@ msgstr "Longueur des lignes de l'afficheur client: nombre de caractères"
 
 #. module: pos_customer_display
 #: field:pos.config,customer_display_line_length:0
-msgid "Line length"
+msgid "Line Length"
 msgstr "Longueur des lignes"
 
 #. module: pos_customer_display
 #. openerp-web
-#: code:addons/pos_customer_display/static/src/js/customer_display.js:69
+#: code:addons/pos_customer_display/static/src/js/customer_display.js:71
 #, python-format
 msgid "Next Customer"
 msgstr "Client suivant"
 
 #. module: pos_customer_display
 #. openerp-web
-#: code:addons/pos_customer_display/static/src/js/customer_display.js:81
+#: code:addons/pos_customer_display/static/src/js/customer_display.js:83
 #, python-format
 msgid "Point of Sale Closed"
 msgstr "Caisse fermée"
 
 #. module: pos_customer_display
 #. openerp-web
-#: code:addons/pos_customer_display/static/src/js/customer_display.js:75
+#: code:addons/pos_customer_display/static/src/js/customer_display.js:77
 #, python-format
 msgid "Point of Sale Open"
 msgstr "Caisse ouverte"
 
 #. module: pos_customer_display
 #. openerp-web
-#: code:addons/pos_customer_display/static/src/js/customer_display.js:48
+#: code:addons/pos_customer_display/static/src/js/customer_display.js:50
 #, python-format
 msgid "TOTAL: "
 msgstr "TOTAL : "
 
 #. module: pos_customer_display
 #. openerp-web
-#: code:addons/pos_customer_display/static/src/js/customer_display.js:63
+#: code:addons/pos_customer_display/static/src/js/customer_display.js:65
 #, python-format
 msgid "Your Change:"
 msgstr "Monnaie à rendre :"

--- a/pos_customer_display/i18n/pos_customer_display.pot
+++ b/pos_customer_display/i18n/pos_customer_display.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-10-24 13:44+0000\n"
-"PO-Revision-Date: 2014-10-24 13:44+0000\n"
+"POT-Creation-Date: 2015-05-16 23:24+0000\n"
+"PO-Revision-Date: 2015-05-16 23:24+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -17,21 +17,28 @@ msgstr ""
 
 #. module: pos_customer_display
 #. openerp-web
-#: code:addons/pos_customer_display/static/src/js/customer_display.js:56
+#: code:addons/pos_customer_display/static/src/js/customer_display.js:58
 #, python-format
 msgid "Cancel Payment"
 msgstr ""
 
 #. module: pos_customer_display
 #: field:pos.config,iface_customer_display:0
-msgid "Customer display"
+msgid "Customer Display"
 msgstr ""
 
 #. module: pos_customer_display
 #. openerp-web
-#: code:addons/pos_customer_display/static/src/js/customer_display.js:41
+#: code:addons/pos_customer_display/static/src/js/customer_display.js:42
 #, python-format
 msgid "Delete Item"
+msgstr ""
+
+#. module: pos_customer_display
+#. openerp-web
+#: code:addons/pos_customer_display/static/src/xml/pos.xml:7
+#, python-format
+msgid "Display Total to Customer"
 msgstr ""
 
 #. module: pos_customer_display
@@ -46,40 +53,40 @@ msgstr ""
 
 #. module: pos_customer_display
 #: field:pos.config,customer_display_line_length:0
-msgid "Line length"
+msgid "Line Length"
 msgstr ""
 
 #. module: pos_customer_display
 #. openerp-web
-#: code:addons/pos_customer_display/static/src/js/customer_display.js:69
+#: code:addons/pos_customer_display/static/src/js/customer_display.js:71
 #, python-format
 msgid "Next Customer"
 msgstr ""
 
 #. module: pos_customer_display
 #. openerp-web
-#: code:addons/pos_customer_display/static/src/js/customer_display.js:81
+#: code:addons/pos_customer_display/static/src/js/customer_display.js:83
 #, python-format
 msgid "Point of Sale Closed"
 msgstr ""
 
 #. module: pos_customer_display
 #. openerp-web
-#: code:addons/pos_customer_display/static/src/js/customer_display.js:75
+#: code:addons/pos_customer_display/static/src/js/customer_display.js:77
 #, python-format
 msgid "Point of Sale Open"
 msgstr ""
 
 #. module: pos_customer_display
 #. openerp-web
-#: code:addons/pos_customer_display/static/src/js/customer_display.js:48
+#: code:addons/pos_customer_display/static/src/js/customer_display.js:50
 #, python-format
 msgid "TOTAL: "
 msgstr ""
 
 #. module: pos_customer_display
 #. openerp-web
-#: code:addons/pos_customer_display/static/src/js/customer_display.js:63
+#: code:addons/pos_customer_display/static/src/js/customer_display.js:65
 #, python-format
 msgid "Your Change:"
 msgstr ""

--- a/pos_customer_display/pos_customer_display.py
+++ b/pos_customer_display/pos_customer_display.py
@@ -3,6 +3,8 @@
 #
 #    POS Customer Display module for Odoo
 #    Copyright (C) 2014 Aurélien DUMAINE
+#    Copyright (C) 2015 Akretion (www.akretion.com)
+#    @author: Alexis de Lattre <alexis.delattre@akretion.com>
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as
@@ -19,26 +21,14 @@
 #
 ##############################################################################
 
-import logging
-from openerp.osv import fields, orm
-
-_logger = logging.getLogger(__name__)
+from openerp import models, fields
 
 
-class pos_config(orm.Model):
-    _name = 'pos.config'
+class PosConfig(models.Model):
     _inherit = 'pos.config'
 
-    _columns = {
-        'iface_customer_display': fields.boolean(
-            'Customer display', help="Display data on the customer display"),
-        'customer_display_line_length': fields.integer(
-            'Line length',
-            help="Length of the LEDs lines of the customer display"),
-    }
-
-    _defaults = {
-        'customer_display_line_length': 20,
-    }
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:
+    iface_customer_display = fields.Boolean(
+        string='Customer Display', help="Display data on the customer display")
+    customer_display_line_length = fields.Integer(
+        string='Line Length', default=20,
+        help="Length of the LEDs lines of the customer display")

--- a/pos_customer_display/pos_customer_display.xml
+++ b/pos_customer_display/pos_customer_display.xml
@@ -6,5 +6,10 @@
                 <script type="text/javascript" src="/pos_customer_display/static/src/js/customer_display.js"></script>
             </xpath>
         </template>
+        <template id="index" name="pos_customer_display index" inherit_id="point_of_sale.index">
+            <xpath expr="//link[@id='pos-stylesheet']" position="after">
+                <link rel="stylesheet" href="/pos_customer_display/static/src/css/pos_customer_display.css" id="pos_customer_display-stylesheet"/>
+            </xpath>
+        </template>
     </data>
 </openerp>

--- a/pos_customer_display/pos_customer_display_demo.xml
+++ b/pos_customer_display/pos_customer_display_demo.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<openerp>
+<data noupdate="1">
+
+
+<record id="point_of_sale.pos_config_main" model="pos.config">
+    <field name="iface_customer_display" eval="True"/>
+</record>
+
+
+</data>
+</openerp>

--- a/pos_customer_display/static/src/css/pos_customer_display.css
+++ b/pos_customer_display/static/src/css/pos_customer_display.css
@@ -1,0 +1,15 @@
+.pos .show-total-to-customer {
+    width: 220px;
+    height: 40px;
+    font-size: 16px;
+    cursor: pointer;
+    text-align: center;
+    box-sizing: border-box;
+}
+
+.pos .show-total-to-customer-div {
+    float: left;
+    margin-right: 15px;
+    margin-left: 15px;
+    margin-top: 20px;
+}

--- a/pos_customer_display/static/src/js/customer_display.js
+++ b/pos_customer_display/static/src/js/customer_display.js
@@ -226,4 +226,24 @@ openerp.pos_customer_display = function(instance){
         return res;
     };
 
+    /* Handle Button "Display Total to Customer" */
+    var _super_OrderWidget_init_ = module.OrderWidget.prototype.init;
+    module.OrderWidget.prototype.init = function(parent, options){
+        _super_OrderWidget_init_.call(this, parent, options);
+        var self = this;
+        this.prepare_text_customer_display = function(event){
+            self.pos.prepare_text_customer_display('addPaymentline', {});
+            event.stopPropagation();
+        };
+    };
+
+    var _super_update_summary_ = module.OrderWidget.prototype.update_summary;
+    module.OrderWidget.prototype.update_summary = function(){
+        _super_update_summary_.call(this);
+        if (this.pos.config.iface_customer_display){
+            this.el.querySelector('.show-total-to-customer')
+                .addEventListener('click', this.prepare_text_customer_display);
+            }
+    };
+
 };

--- a/pos_customer_display/static/src/xml/pos.xml
+++ b/pos_customer_display/static/src/xml/pos.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-extend="OrderWidget" >
+        <t t-jquery=".summary" t-operation="append">
+            <t t-if="widget.pos.config.iface_customer_display">
+                <div class="show-total-to-customer-div">
+                    <button class="show-total-to-customer">
+                       Display Total to Customer
+                    </button>
+                </div>
+            </t>
+        </t>
+    </t>
+</templates>

--- a/pos_payment_terminal/static/src/js/pos_payment_terminal.js
+++ b/pos_payment_terminal/static/src/js/pos_payment_terminal.js
@@ -11,8 +11,6 @@ openerp.pos_payment_terminal = function(instance){
         },
     });
 
-    //TODO make the button bigger and with better name
-
     var _super_PaymentScreenWidget_init_ = module.PaymentScreenWidget.prototype.init;
     module.PaymentScreenWidget.prototype.init = function(parent, options){
         _super_PaymentScreenWidget_init_.call(this, parent, options);

--- a/pos_payment_terminal/static/src/xml/pos_payment_terminal.xml
+++ b/pos_payment_terminal/static/src/xml/pos_payment_terminal.xml
@@ -2,16 +2,11 @@
 <templates id="template" xml:space="preserve">
     <t t-extend="Paymentline" >
         <t t-jquery=".paymentline-input" t-operation="append">
-                <t t-if="line.cashregister.journal.payment_mode">
-				<!--	<t t-if="pos.config.iface_payment_terminal">-->
-						<span class="payment-terminal-transaction-start">
-		                    <button>
-								Start transaction
-			                    <!--<t t-esc="line.cashregister.journal.payment_mode"/> -->
-				            </button>
-						</span>
-				<!--	</t> -->
-                </t> 
-		</t>
-	</t>
+            <t t-if="line.cashregister.journal.payment_mode">
+                <span class="payment-terminal-transaction-start">
+                    <button>Start transaction</button>
+                </span>
+            </t>
+        </t>
+    </t>
 </templates>


### PR DESCRIPTION
The problem with "pos_customer_display" is the following: currently, the only way to know that we have finished to scan the products for the order is when the user clicks on the payment method. So, with the current code of pos_customer_display, we print the TOTAL on the LCD when the user clicks on the payment method. BUT, the customer wants to know the total amount in order to choose the right payment method (for example, the customer could pay by cash or credit card, but he needs to know the total amount to check if he has enough cash). So I added a button "Display Total to Customer", so that we can display the TOTAL on the LCD when we have finished to scan the products.

This development has been inspired by in-field experience and feedback of real-life users :)
