### PR TITLE
[IMP] Show unit price when qty is not 1

### DIFF
--- a/pos_pricelist/__openerp__.py
+++ b/pos_pricelist/__openerp__.py
@@ -18,7 +18,7 @@
 ##############################################################################
 {
     'name': 'POS Pricelist',
-    'version': '1.1.0',
+    'version': '8.0.1.2.0',
     'category': 'Point Of Sale',
     'sequence': 1,
     'author': "Adil Houmadi @Taktik,Odoo Community Association (OCA)",

--- a/pos_pricelist/static/src/css/style.css
+++ b/pos_pricelist/static/src/css/style.css
@@ -144,3 +144,7 @@
   border-width: 0 5px 5px;
   border-bottom-color: #000;
 }
+.pos .pos-right-align {
+    text-align: right;
+    vertical-align: top;
+}

--- a/pos_pricelist/static/src/js/models.js
+++ b/pos_pricelist/static/src/js/models.js
@@ -284,6 +284,14 @@ function pos_pricelist_models(instance, module) {
             }
             return product_taxes;
         },
+        get_display_unit_price: function(){
+            var rounding = this.pos.currency.rounding;
+            if (this.pos.config.display_price_with_taxes) {
+                return round_pr(this.get_price_with_tax() / this.get_quantity(), rounding);
+            } else {
+                return round_pr(this.get_base_price() / this.get_quantity(), rounding);
+            }
+        },
         /**
          * @returns {*}
          */

--- a/pos_pricelist/static/src/js/widgets.js
+++ b/pos_pricelist/static/src/js/widgets.js
@@ -17,6 +17,8 @@
  ******************************************************************************/
 function pos_pricelist_widgets(instance, module) {
 
+    var round_di = instance.web.round_decimals;
+
     module.OrderWidget = module.OrderWidget.extend({
         set_value: function (val) {
             this._super(val);
@@ -61,6 +63,24 @@ function pos_pricelist_widgets(instance, module) {
                 customer = order.get_client();
             }
             this.pos.pricelist_engine.update_products_ui(customer);
+        }
+    });
+
+    module.PosBaseWidget.include({
+        format_pr: function(amount, precision) {
+            // Do not call _super because no addon or XML is using this method
+            var currency = (this.pos && this.pos.currency) ? this.pos.currency : {symbol:'$', position: 'after', rounding: 0.01, decimals: 2};
+            var decimals = currency.decimals;
+
+            if (precision && (typeof this.pos.dp[precision]) !== undefined) {
+                decimals = this.pos.dp[precision];
+            }
+
+            if (typeof amount === 'number') {
+                amount = round_di(amount,decimals).toFixed(decimals);
+                amount = openerp.instances[this.session.name].web.format_value(round_di(amount, decimals), { type: 'float', digits: [69, decimals]});
+            }
+            return amount
         }
     });
 }

--- a/pos_pricelist/static/src/xml/pos.xml
+++ b/pos_pricelist/static/src/xml/pos.xml
@@ -27,4 +27,11 @@
             </div>
         </t>
     </t>
+    <t t-extend="PosTicket">
+        <t t-jquery="t[t-esc='orderline.get_quantity_str_with_unit()']" t-operation="after">
+            <t t-if="orderline.quantity != 1">
+                x<t t-esc="widget.format_pr(orderline.get_display_unit_price())"/>
+            </t>
+        </t>
+    </t>
 </templates>


### PR DESCRIPTION
When qty is not 1 (for example, 2, 3 or 0.56) POS ticket template (PosTicket) is not indicating unit price (but XmlReceipt template, used when proxy configured, implement this feature).
This is specially useful in this addon because unit price would not be product list_price because price list are applied even taking care customer.

So, with this improvement, if qty is equal to 1, unit price is not shown (as now occurs) but if qty is not equal to 1, then unit price is shown.

Please, @ah-taktik and @pablocm-aserti review these changes and do your comments, thanks.
