### PR TITLE
[IMP] Preserve manually modified price in most cases

### DIFF
--- a/pos_pricelist/static/src/js/models.js
+++ b/pos_pricelist/static/src/js/models.js
@@ -162,17 +162,26 @@ function pos_pricelist_models(instance, module) {
          * @param quantity
          */
         set_quantity: function (quantity) {
-            OrderlineParent.prototype.set_quantity.apply(this, arguments);
             var partner = this.order ? this.order.get_client() : null;
             var product = this.product;
             var db = this.pos.db;
+            var old_price = 0;
+            if (this.get_quantity()) {
+                old_price = this.pos.pricelist_engine.compute_price_all(
+                    db, product, partner, this.get_quantity()
+                );
+            }
+            OrderlineParent.prototype.set_quantity.apply(this, arguments);
             var price = this.pos.pricelist_engine.compute_price_all(
                 db, product, partner, quantity
             );
-            if (price !== false) {
+            /* Update the price if the unit price is actually different from
+               the unit price of the previous quantity, to preserve manually
+               entered prices as much as possible. */
+            if (price !== false && price !== old_price) {
                 this.price = price;
+                this.trigger('change', this);
             }
-            this.trigger('change', this);
         },
         /**
          * override this method to take fiscal positions in consideration


### PR DESCRIPTION
Trying to fix a nag here: because odoo pricelists allow for bulk discounts by taking the product quantity into account, the pos_pricelist module updates the price when the quantity button is used in the frontend POS. In our case, we want to enter a manual price sometimes and update the quantity afterwards. The manual price is then overwritten.

This change does not reset the price unless the new quantity actually triggers a different unit price compared to the original quantity. This way, our manually modified price is preserved most of the times, while bulk discounts are still properly applied.
