### PR TITLE
[FIX] travis fail without wkhtmltopdf librairies;

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,12 @@ cache: pip
 
 addons:
   apt:
+    sources:
+      - pov-wkhtmltopdf
     packages:
       - expect-dev  # provides unbuffer utility
       - python-lxml  # because pip installation is slow
+      - wkhtmltopdf
 
 env:
   - VERSION="9.0" LINT_CHECK="1"
@@ -20,6 +23,10 @@ env:
 
 virtualenv:
   system_site_packages: true
+
+before_install:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
 
 install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools


### PR DESCRIPTION
Travis failed in V9 if wkhtmltopdf is not installed. 
ref : 
https://github.com/OCA/pos/pull/77#issuecomment-177561645

This PR fix this bug.
