### PR TITLE
[FIX] Round unit price

### DIFF
--- a/pos_pricelist/static/src/js/models.js
+++ b/pos_pricelist/static/src/js/models.js
@@ -148,7 +148,7 @@ function pos_pricelist_models(instance, module) {
                     db, product, partner, qty
                 );
                 if (price !== false) {
-                    this.price = price;
+                    this.price = round_di(parseFloat(price) || 0, this.pos.dp['Product Price']);
                 }
             }
         },
@@ -179,8 +179,7 @@ function pos_pricelist_models(instance, module) {
                the unit price of the previous quantity, to preserve manually
                entered prices as much as possible. */
             if (price !== false && price !== old_price) {
-                this.price = price;
-                this.trigger('change', this);
+                this.set_unit_price(price);
             }
         },
         /**


### PR DESCRIPTION
Fixes a rounding issue with prices from the pricelist. Reproduce by applying a 10% discount pricelist on an article of 0,75 in a database with product price rounding set to two decimals. Sell in the POS at quantity 4 and you'll find a unit price of 0,68 but a total of 2,70 (4x 0,675). Customer pays 2,70 but the POS order in the backend keeps an open balance of 2 ct. 
