### PR TITLE
[FIX] pos_pricelist: FP taxes with multi-company. Fixes #84

### DIFF
--- a/pos_pricelist/__openerp__.py
+++ b/pos_pricelist/__openerp__.py
@@ -1,27 +1,16 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-# Point Of Sale - Pricelist for POS Odoo
-# Copyright (C) 2014 Taktik (http://www.taktik.be)
-# @author Adil Houmadi <ah@taktik.be>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2014-2015 Taktik (http://www.taktik.be) - Adil Houmadi <ah@taktik.be>
+# © 2016 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 {
     'name': 'POS Pricelist',
-    'version': '8.0.1.2.0',
+    'version': '8.0.1.3.0',
     'category': 'Point Of Sale',
     'sequence': 1,
-    'author': "Adil Houmadi @Taktik,Odoo Community Association (OCA)",
+    'author': "Adil Houmadi @Taktik, "
+              "Serv. Tecnol. Avanzados - Pedro M. Baeza, "
+              "Odoo Community Association (OCA)",
     'summary': 'Pricelist for Point of sale',
     'depends': [
         "point_of_sale",
@@ -32,6 +21,7 @@
         "views/point_of_sale_view.xml",
         "report/report_receipt.xml",
         "security/ir.model.access.csv",
+        "security/account_fiscal_position_security.xml",
     ],
     'demo': [
         'demo/pos_pricelist_demo.yml',
@@ -41,6 +31,4 @@
     ],
     'post_init_hook': "set_pos_line_taxes",
     'installable': True,
-    'application': False,
-    'auto_install': False,
 }

--- a/pos_pricelist/models/__init__.py
+++ b/pos_pricelist/models/__init__.py
@@ -1,20 +1,8 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-# Point Of Sale - Pricelist for POS Odoo
-# Copyright (C) 2015 Taktik (http://www.taktik.be)
-# @author Adil Houmadi <ah@taktik.be>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2015 Taktik (http://www.taktik.be) - Adil Houmadi <ah@taktik.be>
+# © 2016 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import account_fiscal_position
 from . import pos_pricelist
 from . import point_of_sale

--- a/pos_pricelist/models/account_fiscal_position.py
+++ b/pos_pricelist/models/account_fiscal_position.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# © 2016 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import fields, models
+
+
+class AccountFiscalPositionTax(models.Model):
+    _inherit = "account.fiscal.position.tax"
+
+    company_id = fields.Many2one(
+        related="position_id.company_id", string="Company")

--- a/pos_pricelist/security/account_fiscal_position_security.xml
+++ b/pos_pricelist/security/account_fiscal_position_security.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<openerp>
+<data noupdate="1">
+
+    <record id="account_fiscal_position_tax_multi_company_rule" model="ir.rule">
+        <field name="name">Account fiscal position tax multi-company</field>
+        <field name="model_id" ref="model_account_fiscal_position_tax"/>
+        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'child_of', [user.company_id.id])]</field>
+    </record>
+
+</data>
+</openerp>


### PR DESCRIPTION
The object account.fiscal.position.tax doesn't have multi-company rules,
which leads to error in environments with multi-company and these records,
because it finally accesses to the parent fiscal position, which on contrary
has access rules, provoking an access error.

This commit added the field company_id to the model, and add the corresponding
access rule.
