### PR TITLE
[FIX] Rounding problem when partner is selected afterwards

### DIFF
--- a/pos_pricelist/static/src/js/models.js
+++ b/pos_pricelist/static/src/js/models.js
@@ -621,9 +621,8 @@ function pos_pricelist_models(instance, module) {
                     db, product, partner, quantity
                 );
                 if (price !== false) {
-                    line.price = price;
+                    line.set_unit_price(price);
                 }
-                line.trigger('change', line);
             }
         }
     });


### PR DESCRIPTION
Followup of #69. The bug also hid out in another part of the code where the prices of existing lines are recalculated when selecting a partner on an ongoing order.
