### PR TITLE
[IMP] pos_pricelist, not load supplierinfo for not available products

### DIFF
--- a/pos_pricelist/static/src/js/models.js
+++ b/pos_pricelist/static/src/js/models.js
@@ -697,7 +697,7 @@ function pos_pricelist_models(instance, module) {
                         'sequence',
                         'qty',
                         'product_tmpl_id'],
-                    domain: null,
+                    domain: [['product_tmpl_id.available_in_pos','=',true]],
                     loaded: function (self, supplierinfos) {
                         self.db.add_supplierinfo(supplierinfos);
                     }


### PR DESCRIPTION
Avoid loading the supplier info from products not available in pos. When you have many products, it takes too long to load this information.
