### PR TITLE
[Fix][8.0] Fix the way pricelists are selected when a template_id is set as rule of pricelist

### DIFF
--- a/pos_pricelist/static/src/js/models.js
+++ b/pos_pricelist/static/src/js/models.js
@@ -389,7 +389,16 @@ function pos_pricelist_models(instance, module) {
          * @param version
          * @returns {boolean}
          */
-        rule_match: function (item, product, qty, version) {
+        rule_match: function (db, item, product, qty, version) {
+          // get categories
+          var categ_ids = [];
+          if (product.categ_id) {
+              categ_ids.push(product.categ_id[0]);
+              categ_ids = categ_ids.concat(
+                  db.product_category_ancestors[product.categ_id[0]]
+              );
+          }
+
           var cond = true
           var template_false = item.product_tmpl_id === false
           var product_false = item.product_id === false
@@ -452,20 +461,12 @@ function pos_pricelist_models(instance, module) {
                 return false;
             }
 
-            // get categories
-            var categ_ids = [];
-            if (product.categ_id) {
-                categ_ids.push(product.categ_id[0]);
-                categ_ids = categ_ids.concat(
-                    db.product_category_ancestors[product.categ_id[0]]
-                );
-            }
 
             // find items
             var items = [], i, len;
             for (i = 0, len = db.pricelist_item_sorted.length; i < len; i++) {
                 var item = db.pricelist_item_sorted[i];
-                if (this.rule_match(item, product, qty, version)) {
+                if (this.rule_match(db, item, product, qty, version)) {
                   items.push(item)
                 }
             }

--- a/pos_pricelist/static/src/js/models.js
+++ b/pos_pricelist/static/src/js/models.js
@@ -381,6 +381,53 @@ function pos_pricelist_models(instance, module) {
             }
             return version;
         },
+
+        /**
+         * Check if a pricelist rule can be used
+         * @param item
+         * @param product
+         * @param version
+         * @returns {boolean}
+         */
+        rule_match: function (item, product, qty, version) {
+          var cond = true
+          var template_false = item.product_tmpl_id === false
+          var product_false = item.product_id === false
+          var template_match = (
+            !template_false &&
+            item.product_tmpl_id[0] ===  product.product_tmpl_id
+          )
+          var product_match = (
+            !product_false &&
+            item.product_id[0] === product.id
+          )
+
+          // Check if products/template combination is possible
+          cond = cond && (
+            (product_false && template_false) ||
+            (product_match && (template_false || template_match)) ||
+            (template_match && product_false)
+          )
+
+          // Check category
+          cond = cond && (
+              item.categ_id === false ||
+              categ_ids.indexOf(item.categ_id[0]) !== -1
+          )
+
+          // Check version
+          cond = cond && (
+              item.price_version_id[0] === version.id
+          )
+
+          // Check product qty
+          cond = cond && (
+            !item.min_quantity ||
+            qty >= item.min_quantity
+          )
+
+          return cond
+        },
         /**
          * compute the price for the given product
          * @param database
@@ -418,12 +465,8 @@ function pos_pricelist_models(instance, module) {
             var items = [], i, len;
             for (i = 0, len = db.pricelist_item_sorted.length; i < len; i++) {
                 var item = db.pricelist_item_sorted[i];
-                if ((item.product_id === false
-                    || item.product_id[0] === product.id) &&
-                    (item.categ_id === false
-                    || categ_ids.indexOf(item.categ_id[0]) !== -1) &&
-                    (item.price_version_id[0] === version.id)) {
-                    items.push(item);
+                if (this.rule_match(item, product, qty, version)) {
+                  items.push(item)
                 }
             }
 
@@ -436,13 +479,6 @@ function pos_pricelist_models(instance, module) {
             for (i = 0, len = items.length; i < len; i++) {
                 var rule = items[i];
 
-                if (rule.min_quantity && qty < rule.min_quantity) {
-                    continue;
-                }
-                if (rule.product_id && rule.product_id[0]
-                    && product.id != rule.product_id[0]) {
-                    continue;
-                }
                 if (rule.categ_id) {
                     var cat_id = product.categ_id[0];
                     while (cat_id) {
@@ -455,6 +491,7 @@ function pos_pricelist_models(instance, module) {
                         continue;
                     }
                 }
+
                 // Based on field
                 switch (rule.base) {
                     case -1:


### PR DESCRIPTION
Added a method that help matching which pricelist can be used.

It can be inherited which allow other modules to extend the way the
pricelists are chosen.

Also a rule in the while loop could be removed as it duplicated
one of the tests when chosing the available pricelists.

Fix the issue here:
https://github.com/OCA/pos/issues/90
