### PR TITLE
[FIX] pos_pricelist: support attribute prices on product variants

### DIFF
--- a/pos_pricelist/static/src/js/models.js
+++ b/pos_pricelist/static/src/js/models.js
@@ -500,6 +500,9 @@ function pos_pricelist_models(instance, module) {
                                 .hasOwnProperty(price_type.field)) {
                             price =
                                 db.product_by_id[product.id][price_type.field];
+                            if(price_type.field === 'list_price' && product.price_extra){
+                                price += product.price_extra;
+                            }
                         }
                 }
                 if (price !== false) {
@@ -649,7 +652,7 @@ function pos_pricelist_models(instance, module) {
         if (_.size(product_model) == 1) {
             var product_index = parseInt(Object.keys(product_model)[0]);
             pos_model.models[product_index].fields.push(
-                'categ_id', 'seller_ids'
+                'categ_id', 'seller_ids', 'price_extra'
             );
         }
 


### PR DESCRIPTION
This change adds attribute value prices when a product variant price is calculated using the POS pricelist mechanism, analogous to https://github.com/odoo/odoo/blob/8.0/addons/product/product.py#L633

_How to reproduce_
Create a product with an attribute with two values. Assign prices to each of the values. The prices of the resulting product variants will be composed of the product price plus the attribute value prices. With pos_pricelist installed, without this change, the variants will be listed with the product prices without the attribute value prices.
