### PR TITLE
[FIX] pos_pricelist, format_pr error when precision undefined

### DIFF
--- a/pos_pricelist/static/src/js/widgets.js
+++ b/pos_pricelist/static/src/js/widgets.js
@@ -72,7 +72,7 @@ function pos_pricelist_widgets(instance, module) {
             var currency = (this.pos && this.pos.currency) ? this.pos.currency : {symbol:'$', position: 'after', rounding: 0.01, decimals: 2};
             var decimals = currency.decimals;
 
-            if (precision && (typeof this.pos.dp[precision]) !== undefined) {
+            if (precision && this.pos.dp[precision] !== undefined) {
                 decimals = this.pos.dp[precision];
             }
 


### PR DESCRIPTION
In the piece of code:

``` javascript
if (precision && (typeof this.pos.dp[precision]) !== undefined) {
    decimals = this.pos.dp[precision];
}
```

If `this.pos.dp[precision]` is undefined, the typeof will be "undefined" (string), so will never be `undefined`.

I don't know if there is any reason to use the `typeof` here.
