### PR TITLE
10.0 improve pos default empty image

### DIFF
--- a/pos_default_empty_image/README.rst
+++ b/pos_default_empty_image/README.rst
@@ -1,0 +1,85 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=======================
+POS Default Empty Image
+=======================
+
+In the point of sale, trying to load known inexistant images 
+is a waste of time.
+
+
+When you have 8000 products in your Point of Sale and most of them 
+don't have images, you are happy to save thousands of useless requests:
+the POS load way faster.
+
+Technical information
+=====================
+
+Each time the pos instantiate a product, it will add an
+
+    <img src="'/web/binary/image?model=product.product&field=image_medium&id='+product.id;" />
+
+The browser will trigger as many requests than there is different url.
+
+
+If you have many products, the browser will soon reach his limit of 
+network connections to Odoo server and will wait for free slots instead of 
+loading other valuable contents. Then the POS is then very slow to work with.
+
+
+This module adds a field _has_image_ in product.template and will 
+change the product image url to his default placeholder directly in the POS.
+
+Because there is only one url for this placeholder, 
+you will have only one request for all the products with no images.
+
+
+Indeed, if the product has an image, it will load normally.
+
+
+Known issues
+============
+
+
+Updates
+=======
+
+* Feb 2016 : First version
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/web/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback `here <https://github.com/OCA/web/issues/new?body=module:%20pos_default_empty_image%0Aversion:%200.1%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Hparfr <https://github.com/hparfr> `Akretion <https://akretion.com>`_
+* Sylvain LE GAL <https://twitter.com/legalsylvain>
+
+See also this module `pos_improve_images from GRAP 
+<https://github.com/grap/odoo-addons-grap/tree/7.0/pos_improve_images>`_ for OpenERP 7.
+
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/pos_default_empty_image/README.rst
+++ b/pos_default_empty_image/README.rst
@@ -29,14 +29,16 @@ network connections to Odoo server and will wait for free slots instead of
 loading other valuable contents. Then the POS is then very slow to work with.
 
 
-This module adds a field _has_image_ in product.template and will 
-change the product image url to his default placeholder directly in the POS.
+This module adds a field _has_image in product.template.
 
-Because there is only one url for this placeholder, 
-you will have only one request for all the products with no images.
+If product has no image, the product image url is not sent to the POS
 
+In the product list, the display of the product is changed,
+          (Size of the name is increased for better visibility);
 
 Indeed, if the product has an image, it will load normally.
+
+This module is compatible with pos_product_template
 
 
 Known issues
@@ -47,13 +49,16 @@ Updates
 =======
 
 * Feb 2016 : First version
+* Feb 2017 : migration to v10 and improvements for Display - taken from 
+    this module `pos_improve_images from GRAP 
+    <https://github.com/grap/odoo-addons-grap/tree/7.0/pos_improve_images>`_ for OpenERP 7.
 
 Bug Tracker
 ===========
 
-Bugs are tracked on `GitHub Issues <https://github.com/OCA/web/issues>`_.
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/pos/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
-If you spotted it first, help us smashing it by providing a detailed and welcomed feedback `here <https://github.com/OCA/web/issues/new?body=module:%20pos_default_empty_image%0Aversion:%200.1%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback `here <https://github.com/OCA/pos/issues/new?body=module:%20pos_default_empty_image%0Aversion:%200.1%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 
 Credits
@@ -64,9 +69,6 @@ Contributors
 
 * Hparfr <https://github.com/hparfr> `Akretion <https://akretion.com>`_
 * Sylvain LE GAL <https://twitter.com/legalsylvain>
-
-See also this module `pos_improve_images from GRAP 
-<https://github.com/grap/odoo-addons-grap/tree/7.0/pos_improve_images>`_ for OpenERP 7.
 
 
 Maintainer

--- a/pos_default_empty_image/__init__.py
+++ b/pos_default_empty_image/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/pos_default_empty_image/__manifest__.py
+++ b/pos_default_empty_image/__manifest__.py
@@ -9,7 +9,14 @@
     'author': "Akretion, GRAP, Odoo Community Association (OCA)",
     'website': "https://akretion.com",
     'license': 'AGPL-3',
-    'depends': ['point_of_sale'],
-    'data': ['view/view.xml'],
-    'qweb': [],
+    'depends': [
+        'point_of_sale',
+    ],
+    'data': [
+        'view/templates.xml',
+    ],
+    'qweb': [
+        'static/src/xml/pos_default_empty_image.xml',
+    ],
+    'installable': True,
 }

--- a/pos_default_empty_image/__manifest__.py
+++ b/pos_default_empty_image/__manifest__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# © <2015> <Akretion, GRAP, OCA>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    'name': 'POS Default empty image',
+    'version': '10.0.0.1.0',
+    'category': 'Point Of Sale',
+    'summary': 'Optimise load time for products with no image',
+    'author': "Akretion, GRAP, Odoo Community Association (OCA)",
+    'website': "https://akretion.com",
+    'license': 'AGPL-3',
+    'depends': ['point_of_sale'],
+    'data': ['view/view.xml'],
+    'qweb': [],
+}

--- a/pos_default_empty_image/models/__init__.py
+++ b/pos_default_empty_image/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product

--- a/pos_default_empty_image/models/product.py
+++ b/pos_default_empty_image/models/product.py
@@ -8,8 +8,9 @@ from odoo import models, fields, api
 class ProductTemplate(models.Model):
     _inherit = 'product.template'
 
-    @api.one
+    @api.multi
     def _get_has_image(self):
+        self.ensure_one()
         self.has_image = self.image is not False
 
     has_image = fields.Boolean(compute='_get_has_image', string='Has Image')

--- a/pos_default_empty_image/models/product.py
+++ b/pos_default_empty_image/models/product.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# © <2015> <Akretion, GRAP, OCA>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models, fields, api
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    @api.one
+    def _get_has_image(self):
+        self.has_image = self.image is not False
+
+    has_image = fields.Boolean(compute='_get_has_image', string='Has Image')

--- a/pos_default_empty_image/static/src/css/pos_default_empty_image.css
+++ b/pos_default_empty_image/static/src/css/pos_default_empty_image.css
@@ -1,0 +1,35 @@
+/******************************************************************************
+    Point Of Sale - Improve Images module for OpenERP
+    Copyright (C) 2014 GRAP (http://www.grap.coop)
+    @author Julien WESTE
+    @author Sylvain LE GAL (https://twitter.com/legalsylvain)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
+/* 
+    New display for 'product-img' and 'product-name' where there isn't image;
+*/
+
+.product-img-without-image{
+    height:25px !important;
+}
+
+.product-name-without-image{
+    bottom:auto !important;
+    top:25px !important;
+    padding-top:3px !important;
+    height:100px !important;
+    font-size: 16px !important;
+}

--- a/pos_default_empty_image/static/src/css/pos_default_empty_image.css
+++ b/pos_default_empty_image/static/src/css/pos_default_empty_image.css
@@ -30,7 +30,9 @@
     bottom:auto !important;
     top:25px !important;
     padding-top:3px !important;
-    height:100px !important;
-    font-size: 16px !important;
+    height:80px !important;
+    font-size: 24px !important;
+    line-height: 20px;
     text-align: center;
+    word-wrap: break-word;
 }

--- a/pos_default_empty_image/static/src/css/pos_default_empty_image.css
+++ b/pos_default_empty_image/static/src/css/pos_default_empty_image.css
@@ -32,4 +32,5 @@
     padding-top:3px !important;
     height:100px !important;
     font-size: 16px !important;
+    text-align: center;
 }

--- a/pos_default_empty_image/static/src/js/pos_default_empty_image.js
+++ b/pos_default_empty_image/static/src/js/pos_default_empty_image.js
@@ -1,17 +1,42 @@
 odoo.define('pos_default_empty_image', function (require) {
-"use strict";
+    "use strict";
 
     var models = require('point_of_sale.models');
     var screens = require('point_of_sale.screens');
+
+    var core = require('web.core');
+
+    var QWeb = core.qweb;
 
     //don't try to get an image if we know the product ain't one
     var ProductListImageWidget = screens.ProductListWidget.include({
         get_product_image_url: function(product){
             if (product.has_image)
                 return this._super(product);
+        },
 
-            return '/web/static/src/img/placeholder.png';
-        }
+        // Change product display if product has no image;
+        render_product: function(product){
+            if (product.has_image){
+                return this._super(product);
+            }
+            else {
+                var cached = this.product_cache.get_node(product.id);
+                if(!cached){
+                    var image_url = this.get_product_image_url(product);
+                    var product_html = QWeb.render('ProductNoImage',{
+                        widget:  this,
+                        product: product,
+                    });
+                    var product_node = document.createElement('div');
+                    product_node.innerHTML = product_html;
+                    product_node = product_node.childNodes[1];
+                    this.product_cache.cache_node(product.id,product_node);
+                    return product_node;
+                }
+                return cached;
+            }
+        },
     });
 
     var _super_posmodel = models.PosModel.prototype;

--- a/pos_default_empty_image/static/src/js/pos_default_empty_image.js
+++ b/pos_default_empty_image/static/src/js/pos_default_empty_image.js
@@ -1,0 +1,26 @@
+odoo.define('pos_default_empty_image', function (require) {
+"use strict";
+
+    var models = require('point_of_sale.models');
+    var screens = require('point_of_sale.screens');
+
+    //don't try to get an image if we know the product ain't one
+    var ProductListImageWidget = screens.ProductListWidget.include({
+        get_product_image_url: function(product){
+            if (product.has_image)
+                return this._super(product);
+
+            return '/web/static/src/img/placeholder.png';
+        }
+    });
+
+    var _super_posmodel = models.PosModel.prototype;
+    models.PosModel = models.PosModel.extend({
+        initialize: function (session, attributes) {
+            var product_model = _.find(this.models, function(model){ return model.model === 'product.product'; });
+            product_model.fields.push('has_image');
+
+            return _super_posmodel.initialize.call(this, session, attributes);
+        },
+    });
+});

--- a/pos_default_empty_image/static/src/xml/pos_default_empty_image.xml
+++ b/pos_default_empty_image/static/src/xml/pos_default_empty_image.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="ProductNoImage">
+        <span class='product' t-att-data-product-id="product.id">
+            <div class="product-img-without-image">
+                <t t-if="!product.to_weight">
+                    <span class="price-tag">
+                        <t t-esc="widget.format_currency(product.price,'Product Price')"/>
+                    </span>
+                </t>
+                <t t-if="product.to_weight">
+                    <span class="price-tag">
+                        <t t-esc="widget.format_currency(product.price,'Product Price')+'/'+widget.pos.units_by_id[product.uom_id[0]].name"/>
+                    </span>
+                </t>
+            </div>
+            <div class="product-name-without-image">
+                <t t-esc="product.display_name"/>
+            </div>
+        </span>
+    </t>
+</templates>
+

--- a/pos_default_empty_image/view/templates.xml
+++ b/pos_default_empty_image/view/templates.xml
@@ -4,5 +4,8 @@
         <xpath expr="." position="inside">
             <script type="text/javascript" src="/pos_default_empty_image/static/src/js/pos_default_empty_image.js"></script>
         </xpath>
+        <xpath expr="//link[@id='pos-stylesheet']" position="after">
+            <link rel="stylesheet" href="/pos_default_empty_image/static/src/css/pos_default_empty_image.css"/>
+        </xpath>
     </template>
 </odoo>

--- a/pos_default_empty_image/view/view.xml
+++ b/pos_default_empty_image/view/view.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <template id="assets_backend" name="pos_default_empty_image assets" inherit_id="point_of_sale.assets">
+        <xpath expr="." position="inside">
+            <script type="text/javascript" src="/pos_default_empty_image/static/src/js/pos_default_empty_image.js"></script>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
This PR improves pos_default_empty_image module (inspired from https://github.com/grap/odoo-addons-grap/tree/7.0/pos_improve_images)
If the product has no image : 
   - no product image url is sent to the POS. The placeholder image is useless in POS...
   - product's name is bigger for better visibility

@legalsylvain I did not manage to addClass in the original Product template as you did in v7 [here](https://github.com/grap/odoo-addons-grap/blob/7.0/pos_improve_images/static/src/js/pii.js)
Could you have a look and improve ?
Thanks in advance