### PR TITLE
[8.0] pos_default_empty_image fix import

### DIFF
--- a/pos_default_empty_image/__init__.py
+++ b/pos_default_empty_image/__init__.py
@@ -1,0 +1,1 @@
+from . import product


### PR DESCRIPTION
Trivial fix. 
supersed : https://github.com/OCA/pos/pull/153