### PR TITLE
[8.0][FIX] README.rst bad format in title

### DIFF
--- a/pos_margin/README.rst
+++ b/pos_margin/README.rst
@@ -1,3 +1,4 @@
+=============================================
 This module adds the 'Margin' on sales order.
 =============================================
 
@@ -6,7 +7,7 @@ This module adds the 'Margin' on sales order.
    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
    :alt: License: AGPL-3
 
-===================
+
 Margin on PoS order
 ===================
 


### PR DESCRIPTION
Error when the description is showed:

  File "/usr/lib/python2.7/dist-packages/docutils/core.py", line 662, in publish_programmatically
    output = pub.publish(enable_exit_status=enable_exit_status)
  File "/usr/lib/python2.7/dist-packages/docutils/core.py", line 217, in publish
    self.settings)
  File "/usr/lib/python2.7/dist-packages/docutils/readers/__init__.py", line 72, in read
    self.parse()
  File "/usr/lib/python2.7/dist-packages/docutils/readers/__init__.py", line 78, in parse
    self.parser.parse(self.input, document)
  File "/usr/lib/python2.7/dist-packages/docutils/parsers/rst/__init__.py", line 172, in parse
    self.statemachine.run(inputlines, document, inliner=self.inliner)
  File "/usr/lib/python2.7/dist-packages/docutils/parsers/rst/states.py", line 171, in run
    input_source=document['source'])
  File "/usr/lib/python2.7/dist-packages/docutils/statemachine.py", line 239, in run
    context, state, transitions)
  File "/usr/lib/python2.7/dist-packages/docutils/statemachine.py", line 460, in check_line
    return method(match, context, next_state)
  File "/usr/lib/python2.7/dist-packages/docutils/parsers/rst/states.py", line 2727, in underline
    self.section(title, source, style, lineno - 1, messages)
  File "/usr/lib/python2.7/dist-packages/docutils/parsers/rst/states.py", line 328, in section
    self.new_subsection(title, lineno, messages)
  File "/usr/lib/python2.7/dist-packages/docutils/parsers/rst/states.py", line 396, in new_subsection
    node=section_node, match_titles=True)
  File "/usr/lib/python2.7/dist-packages/docutils/parsers/rst/states.py", line 283, in nested_parse
    node=node, match_titles=match_titles)
  File "/usr/lib/python2.7/dist-packages/docutils/parsers/rst/states.py", line 196, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "/usr/lib/python2.7/dist-packages/docutils/statemachine.py", line 239, in run
    context, state, transitions)
  File "/usr/lib/python2.7/dist-packages/docutils/statemachine.py", line 460, in check_line
    return method(match, context, next_state)
  File "/usr/lib/python2.7/dist-packages/docutils/parsers/rst/states.py", line 2727, in underline
    self.section(title, source, style, lineno - 1, messages)
  File "/usr/lib/python2.7/dist-packages/docutils/parsers/rst/states.py", line 327, in section
    if self.check_subsection(source, style, lineno):
  File "/usr/lib/python2.7/dist-packages/docutils/parsers/rst/states.py", line 356, in check_subsection
    self.parent += self.title_inconsistent(source, lineno)
  File "/usr/lib/python2.7/dist-packages/docutils/parsers/rst/states.py", line 374, in title_inconsistent
    line=lineno)
  File "/usr/lib/python2.7/dist-packages/docutils/utils/__init__.py", line 235, in severe
    return self.system_message(self.SEVERE_LEVEL, *args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/docutils/utils/__init__.py", line 193, in system_message
    raise SystemMessage(msg, level)
SystemMessage: <string>:57: (SEVERE/4) Title level inconsistent: