### PR TITLE
[FIX] re-introduce pos_remove_pos_category and avoid monkey patch and error on foreign key constraint

### DIFF
--- a/pos_remove_pos_category/README.rst
+++ b/pos_remove_pos_category/README.rst
@@ -1,0 +1,63 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License
+
+POS Remove POS Category
+=======================
+
+This module was written to replace POS categories by product categories
+in the point of sale.
+
+Important notes
+---------------
+- When the module is installed the link beetween products and POS categories
+  is **overwritten** by a link beetween products and product categories
+  (the link is the field pos_categ_id in the table product_template)
+- When the module is uninstalled the link beetween products and POS categories
+  is restored in an **empty** state (NULL values)
+
+Installation
+============
+
+This module depends on the `point_of_sale` Odoo official module.
+
+Configuration
+=============
+
+No configuration is needed just use product categories as standard
+pos categories.
+You may uncheck 'Available in the Point of Sale' field
+in regular product categories if you want that a category becomes invisible
+in POS.
+Children categories will becomes invisible too, whatever their checkbox state.
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/pos/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/pos/issues/new?body=module:%20pos_remove_pos_category%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Sylvain Calador <sylvain.calador@akretion.com>
+* Simone Orsi <simone.orsi@camptocamp.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/pos_remove_pos_category/README.rst
+++ b/pos_remove_pos_category/README.rst
@@ -48,6 +48,7 @@ Contributors
 
 * Sylvain Calador <sylvain.calador@akretion.com>
 * Simone Orsi <simone.orsi@camptocamp.com>
+* Cédric Pigeon <cedric.pigeon@acsone.eu>
 
 Maintainer
 ----------

--- a/pos_remove_pos_category/__init__.py
+++ b/pos_remove_pos_category/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2015-TODAY Akretion (<http://www.akretion.com>).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/pos_remove_pos_category/__manifest__.py
+++ b/pos_remove_pos_category/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2015-TODAY Akretion (<http://www.akretion.com>).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    'name': 'POS Remove POS Category',
+    'version': '10.0.0.1.0',
+    'author': 'Akretion, Camptocamp SA, Odoo Community Association (OCA)',
+    'category': 'Sales Management',
+    'depends': [
+        'point_of_sale',
+    ],
+    'demo': [],
+    'website': 'https://www.akretion.com',
+    'data': [
+        'views/assets.xml',
+        'views/pos_view.xml',
+        'views/pos_category_view.xml',
+    ],
+    'installable': True,
+}

--- a/pos_remove_pos_category/__manifest__.py
+++ b/pos_remove_pos_category/__manifest__.py
@@ -3,8 +3,9 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'POS Remove POS Category',
-    'version': '10.0.0.1.0',
-    'author': 'Akretion, Camptocamp SA, Odoo Community Association (OCA)',
+    'version': '10.0.2.0.0',
+    'author': 'Akretion, Camptocamp SA, ACSONE SA/NV, '
+              'Odoo Community Association (OCA)',
     'category': 'Sales Management',
     'depends': [
         'point_of_sale',

--- a/pos_remove_pos_category/i18n/fr.po
+++ b/pos_remove_pos_category/i18n/fr.po
@@ -1,0 +1,74 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * pos_remove_pos_category
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+# leemannd <denis.leemann@camptocamp.com>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-07-12 02:44+0000\n"
+"PO-Revision-Date: 2017-07-12 02:44+0000\n"
+"Last-Translator: leemannd <denis.leemann@camptocamp.com>, 2017\n"
+"Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: fr\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: pos_remove_pos_category
+#: model:ir.ui.view,arch_db:pos_remove_pos_category.product_category_list_view
+msgid "Available in POS"
+msgstr "Disponible dans le PDV"
+
+#. module: pos_remove_pos_category
+#: model:ir.model.fields,field_description:pos_remove_pos_category.field_product_category_available_in_pos
+msgid "Available in the Point of Sale"
+msgstr "Disponible dans le Point de Vente"
+
+#. module: pos_remove_pos_category
+#: model:ir.model.fields,help:pos_remove_pos_category.field_product_category_available_in_pos
+msgid ""
+"Check if you want this category to appear in Point Of Sale.\n"
+"If you uncheck, children categories will becomes invisible too, whatever their checkbox state."
+msgstr ""
+"Cochez si vous voulez que cette catégorie apparaisse dans le Point de Vente.\n"
+"Si vous décochez, les catégories enfants deviendront invisible également, quel que soit l'état de leur case à cocher."
+
+#. module: pos_remove_pos_category
+#: model:ir.model.fields,field_description:pos_remove_pos_category.field_product_category_image
+msgid "Image"
+msgstr "Image"
+
+#. module: pos_remove_pos_category
+#: model:ir.model.fields,field_description:pos_remove_pos_category.field_product_category_image_medium
+msgid "Image medium"
+msgstr ""
+
+#. module: pos_remove_pos_category
+#: model:ir.model,name:pos_remove_pos_category.model_ir_module_module
+msgid "Module"
+msgstr "Module"
+
+#. module: pos_remove_pos_category
+#: model:ir.model,name:pos_remove_pos_category.model_product_category
+msgid "Product Category"
+msgstr "Catégorie de Produit"
+
+#. module: pos_remove_pos_category
+#: model:ir.model,name:pos_remove_pos_category.model_product_template
+msgid "Product Template"
+msgstr "Modèle d'article"
+
+#. module: pos_remove_pos_category
+#: model:ir.model.fields,help:pos_remove_pos_category.field_product_category_image
+msgid "Show Image Category in Form View"
+msgstr ""
+
+#. module: pos_remove_pos_category
+#: model:ir.model.fields,help:pos_remove_pos_category.field_product_category_image_medium
+msgid "Show image category button in POS"
+msgstr ""

--- a/pos_remove_pos_category/i18n/it.po
+++ b/pos_remove_pos_category/i18n/it.po
@@ -1,0 +1,73 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * pos_remove_pos_category
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-03-01 04:05+0000\n"
+"PO-Revision-Date: 2017-03-01 04:05+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Italian (https://www.transifex.com/oca/teams/23907/it/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: it\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: pos_remove_pos_category
+#: model:ir.ui.view,arch_db:pos_remove_pos_category.product_category_list_view
+msgid "Available in POS"
+msgstr "Disponibile nel POS"
+
+#. module: pos_remove_pos_category
+#: model:ir.model.fields,field_description:pos_remove_pos_category.field_product_category_available_in_pos
+msgid "Available in the Point of Sale"
+msgstr "Disponibile nel POS"
+
+#. module: pos_remove_pos_category
+#: model:ir.model.fields,help:pos_remove_pos_category.field_product_category_available_in_pos
+msgid ""
+"Check if you want this category to appear in Point Of Sale.\n"
+"If you uncheck, children categories will becomes invisible too, whatever their checkbox state."
+msgstr ""
+"Attiva per far apparire questa categoria nel POS.\n"
+"Se disattivato, anche le sotto-categorie saranno nascoste, anche se attivate singolarmente."
+
+#. module: pos_remove_pos_category
+#: model:ir.model.fields,field_description:pos_remove_pos_category.field_product_category_image
+msgid "Image"
+msgstr ""
+
+#. module: pos_remove_pos_category
+#: model:ir.model.fields,field_description:pos_remove_pos_category.field_product_category_image_medium
+msgid "Image medium"
+msgstr ""
+
+#. module: pos_remove_pos_category
+#: model:ir.model,name:pos_remove_pos_category.model_ir_module_module
+msgid "Module"
+msgstr "Module"
+
+#. module: pos_remove_pos_category
+#: model:ir.model,name:pos_remove_pos_category.model_product_category
+msgid "Product Category"
+msgstr "Categoria Prodotto"
+
+#. module: pos_remove_pos_category
+#: model:ir.model,name:pos_remove_pos_category.model_product_template
+msgid "Product Template"
+msgstr "Template Prodotto"
+
+#. module: pos_remove_pos_category
+#: model:ir.model.fields,help:pos_remove_pos_category.field_product_category_image
+msgid "Show Image Category in Form View"
+msgstr ""
+
+#. module: pos_remove_pos_category
+#: model:ir.model.fields,help:pos_remove_pos_category.field_product_category_image_medium
+msgid "Show image category button in POS"
+msgstr ""

--- a/pos_remove_pos_category/i18n/nl_NL.po
+++ b/pos_remove_pos_category/i18n/nl_NL.po
@@ -1,0 +1,71 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * pos_remove_pos_category
+# 
+# Translators:
+# Peter Hageman <hageman.p@gmail.com>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-05-30 02:44+0000\n"
+"PO-Revision-Date: 2017-05-30 02:44+0000\n"
+"Last-Translator: Peter Hageman <hageman.p@gmail.com>, 2017\n"
+"Language-Team: Dutch (Netherlands) (https://www.transifex.com/oca/teams/23907/nl_NL/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: nl_NL\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: pos_remove_pos_category
+#: model:ir.ui.view,arch_db:pos_remove_pos_category.product_category_list_view
+msgid "Available in POS"
+msgstr "Beschikbaar in de Kassa"
+
+#. module: pos_remove_pos_category
+#: model:ir.model.fields,field_description:pos_remove_pos_category.field_product_category_available_in_pos
+msgid "Available in the Point of Sale"
+msgstr "Beschikbaar in de Kassa"
+
+#. module: pos_remove_pos_category
+#: model:ir.model.fields,help:pos_remove_pos_category.field_product_category_available_in_pos
+msgid ""
+"Check if you want this category to appear in Point Of Sale.\n"
+"If you uncheck, children categories will becomes invisible too, whatever their checkbox state."
+msgstr ""
+
+#. module: pos_remove_pos_category
+#: model:ir.model.fields,field_description:pos_remove_pos_category.field_product_category_image
+msgid "Image"
+msgstr "Afbeelding"
+
+#. module: pos_remove_pos_category
+#: model:ir.model.fields,field_description:pos_remove_pos_category.field_product_category_image_medium
+msgid "Image medium"
+msgstr ""
+
+#. module: pos_remove_pos_category
+#: model:ir.model,name:pos_remove_pos_category.model_ir_module_module
+msgid "Module"
+msgstr "Module"
+
+#. module: pos_remove_pos_category
+#: model:ir.model,name:pos_remove_pos_category.model_product_category
+msgid "Product Category"
+msgstr "Productcategorie"
+
+#. module: pos_remove_pos_category
+#: model:ir.model,name:pos_remove_pos_category.model_product_template
+msgid "Product Template"
+msgstr "Productsjabloon"
+
+#. module: pos_remove_pos_category
+#: model:ir.model.fields,help:pos_remove_pos_category.field_product_category_image
+msgid "Show Image Category in Form View"
+msgstr ""
+
+#. module: pos_remove_pos_category
+#: model:ir.model.fields,help:pos_remove_pos_category.field_product_category_image_medium
+msgid "Show image category button in POS"
+msgstr "Toon afbeelding categorie-knop in Kassa"

--- a/pos_remove_pos_category/i18n/pos_remove_pos_category.pot
+++ b/pos_remove_pos_category/i18n/pos_remove_pos_category.pot
@@ -1,0 +1,47 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* pos_remove_pos_category
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-07-24 07:13+0000\n"
+"PO-Revision-Date: 2015-07-24 07:13+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: pos_remove_pos_category
+#: view:product.category:pos_remove_pos_category.product_category_list_view
+msgid "Available in POS"
+msgstr ""
+
+#. module: pos_remove_pos_category
+#: field:product.category,available_in_pos:0
+msgid "Available in the Point of Sale"
+msgstr ""
+
+#. module: pos_remove_pos_category
+#: help:product.category,available_in_pos:0
+msgid "Check if you want this category to appear in Point Of Sale.\n"
+"If you uncheck, children categories will becomes invisible too, whatever their checkbox state."
+msgstr ""
+
+#. module: pos_remove_pos_category
+#: model:ir.model,name:pos_remove_pos_category.model_ir_module_module
+msgid "Module"
+msgstr ""
+
+#. module: pos_remove_pos_category
+#: model:ir.model,name:pos_remove_pos_category.model_product_category
+msgid "Product Category"
+msgstr ""
+
+#. module: pos_remove_pos_category
+#: model:ir.model,name:pos_remove_pos_category.model_product_template
+msgid "Product Template"
+msgstr ""

--- a/pos_remove_pos_category/models/__init__.py
+++ b/pos_remove_pos_category/models/__init__.py
@@ -1,0 +1,2 @@
+from . import module
+from . import product

--- a/pos_remove_pos_category/models/module.py
+++ b/pos_remove_pos_category/models/module.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2015-TODAY Akretion (<http://www.akretion.com>).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class Module(models.Model):
+
+    _inherit = 'ir.module.module'
+
+    def module_uninstall(self):
+
+        for module in self:
+            if module.name == 'pos_remove_pos_category':
+
+                # As we have loose previous POS categs restore them
+                # in a sane empty state
+
+                self._cr.execute(
+                    'UPDATE product_template SET pos_categ_id=NULL')
+                # And restore original constraint
+                self._cr.execute('''
+                    ALTER TABLE product_template
+                    DROP CONSTRAINT IF EXISTS
+                    product_template_pos_categ_id_fkey
+                ''')
+
+                self._cr.execute('''
+                    ALTER TABLE product_template ADD CONSTRAINT
+                    "product_template_pos_categ_id_fkey"
+                    FOREIGN KEY (pos_categ_id)
+                    REFERENCES pos_category(id) ON DELETE SET NULL;
+                ''')
+
+                # Restore POS category menu action
+                # in SQL because pool/env is not available here
+                self._cr.execute('''
+                    UPDATE ir_act_window iaw SET res_model='pos.category'
+                    FROM ir_model_data imd
+                    WHERE
+                        iaw.id = imd.res_id AND
+                        imd.model = 'ir.actions.act_window' AND
+                        imd.name = 'product_pos_category_action'
+                ''')
+
+                break
+
+        return super(Module, self).module_uninstall()

--- a/pos_remove_pos_category/models/product.py
+++ b/pos_remove_pos_category/models/product.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2015-TODAY Akretion (<http://www.akretion.com>).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import sys
+from odoo import models, fields, api, tools
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    pos_categ_id = fields.Many2one('product.category',
+                                   store=True, related='categ_id')
+
+    @api.model
+    def create(self, vals):
+        if 'categ_id' in vals:
+            vals['pos_categ_id'] = vals['categ_id']
+        return super(ProductTemplate, self).create(vals)
+
+    @api.multi
+    def write(self, vals):
+        if 'pos_categ_id' in vals and not vals['pos_categ_id']:
+            del vals['pos_categ_id']
+        return super(ProductTemplate, self).write(vals)
+
+
+class ProductCategory(models.Model):
+    _inherit = 'product.category'
+
+    image = fields.Binary(help='Show Image Category in Form View')
+    image_medium = fields.Binary(help='Show image category button in POS',
+                                 compute="_compute_image",
+                                 inverse="_set_image",
+                                 store=True)
+    available_in_pos = fields.Boolean(
+        string="Available in the Point of Sale",
+        default=True,
+        help="Check if you want this category to appear in Point Of Sale.\n"
+             "If you uncheck, children categories will becomes invisible too, "
+             "whatever their checkbox state.")
+
+    @api.multi
+    def _compute_image(self):
+        return dict(
+            (rec.id, tools.image_get_resized_images(rec.image)) for rec in
+            self)
+
+    @api.one
+    def _set_image(self):
+        return self.write(
+            {'image': tools.image_resize_image_big(self.image_medium)})
+
+
+_auto_end_original = models.BaseModel._auto_end
+
+
+@api.model
+def _auto_end(self):
+    """ Create the foreign keys recorded by _auto_init.
+        (pos_remove_pos_category monkey patching)
+    """
+    module = self._context['module']
+    foreign_keys = []
+    patched = 'odoo.addons.pos_remove_pos_category' in sys.modules
+
+    for fk in self._foreign_keys:
+        t = fk[0]
+        k = fk[1]
+        if patched and (t, k) == ('product_template', 'pos_categ_id'):
+            if module == 'pos_remove_pos_category':
+                self._cr.execute('''
+                    ALTER TABLE product_template
+                    DROP CONSTRAINT IF EXISTS
+                    product_template_pos_categ_id_fkey
+                ''')
+                self._cr.execute('''
+                    UPDATE product_template
+                    SET pos_categ_id = categ_id;
+                ''')
+                self._cr.execute('''
+                    ALTER TABLE product_template ADD CONSTRAINT
+                    "product_template_pos_categ_id_fkey"
+                    FOREIGN KEY (pos_categ_id)
+                    REFERENCES product_category(id) ON DELETE SET NULL;
+                ''')
+            continue
+        foreign_keys.append(fk)
+    self._foreign_keys = foreign_keys
+    return _auto_end_original
+
+
+models.BaseModel._auto_end = _auto_end

--- a/pos_remove_pos_category/static/src/js/pos_remove_pos_category.js
+++ b/pos_remove_pos_category/static/src/js/pos_remove_pos_category.js
@@ -1,0 +1,38 @@
+/******************************************************************************
+ * Copyright (C) 2015-2016 Akretion (<http://www.akretion.com>).
+ * Copyright (C) 2017-TODAY Camptocamp SA (<http://www.camptocamp.com>).
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+ ******************************************************************************/
+
+odoo.define('pos_remove_pos_category.remove_pos_category', function (require) {
+    "use strict";
+
+    var core = require('web.core');
+    var pos_models = require('point_of_sale.models');
+    var pos_screens = require('point_of_sale.screens');
+    var Model = require('web.DataModel');
+    var _t = core._t;
+
+    var _pos_super = pos_models.PosModel.prototype;
+    pos_models.PosModel = pos_models.PosModel.extend({
+        initialize: function(session, attributes) {
+            for (var i = 0 ; i < this.models.length; i++){
+                if (this.models[i].model == 'pos.category') {
+                    this.models[i].model = 'product.category';
+                    this.models[i].domain = [['available_in_pos', '=', true]];
+                }
+            }
+            return _pos_super.initialize.apply(this, arguments);
+        }
+    });
+
+    // override method js POS (widgets.js)
+    // change pos.category by product.category
+    pos_screens.ProductCategoriesWidget.include({
+        get_image_url: function(category){
+            var image_url = '/web/binary/image?model=product.category&field=image_medium&id=';
+            return window.location.origin + image_url + category.id;
+        }
+    });
+
+});

--- a/pos_remove_pos_category/views/assets.xml
+++ b/pos_remove_pos_category/views/assets.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="assets" inherit_id="point_of_sale.assets">
+      <xpath expr="." position="inside">
+          <script type="text/javascript" src="/pos_remove_pos_category/static/src/js/pos_remove_pos_category.js"></script>
+      </xpath>
+    </template>
+</odoo>

--- a/pos_remove_pos_category/views/pos_category_view.xml
+++ b/pos_remove_pos_category/views/pos_category_view.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="product_category_form_view" model="ir.ui.view">
+        <field name="model">product.category</field>
+        <field name="inherit_id" ref="product.product_category_form_view"/>
+        <!-- Priority to avoid to break account and logistics fields-->
+        <field name="priority">20</field>
+        <field name="arch" type="xml">
+            <field name="type" position="after">
+                <field name="available_in_pos"/>
+            </field>
+            <xpath expr="//div[contains(@class,'oe_title')]" position="before">
+                <field name="image_medium"
+                       widget="image"
+                       class="oe_avatar"
+                       options='{"size": [100, 100]}'/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="product_category_list_view" model="ir.ui.view">
+        <field name="model">product.category</field>
+        <field name="inherit_id" ref="product.product_category_list_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='display_name']" position="after">
+                <field name="available_in_pos" string="Available in POS"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/pos_remove_pos_category/views/pos_view.xml
+++ b/pos_remove_pos_category/views/pos_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="product_template_form_view" model="ir.ui.view">
+        <field name="name">product.template.form.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="priority" eval="100"/>
+        <field name="arch" type="xml">
+            <field name="pos_categ_id" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+        </field>
+    </record>
+    <record id="point_of_sale.product_pos_category_action" model="ir.actions.act_window">
+        <field name="res_model">product.category</field>
+    </record>
+</odoo>


### PR DESCRIPTION
In version 10.0 monkey patches are not used anymore but replaced by an inheritance of BaseModel.
Previously this addon used a monkey patch to bypass a foreign key creation on column pos_categ_id of product_template model. These was triggered by an update of point_of_sale.

Unfortunately in V10.0, the module pos_remove_pos_category is not yet in the registry while the foreign key is created. So it is impossible to avoid it.
So, on an empty database, no problem but once you have one product linked to a product_category, it is impossible to update the point_of_sale module because it cannot find the pos_categ_id value in pos_category table.
This PR intend to fix this problem by switching the comodel on pos_categ_id and using a related as before but NOT STORED. A search method is added to allowing research on the field.
