### PR TITLE
[IMP] API consistency

### DIFF
--- a/pos_picking_load/models/stock_picking.py
+++ b/pos_picking_load/models/stock_picking.py
@@ -43,10 +43,11 @@ class StockPicking(models.Model):
         fields = self._prepare_fields_for_pos_list()
         return self.search_read(condition, fields, limit=10)
 
-    @api.model
-    def _prepare_pos_order(self, picking):
+    @api.multi
+    def load_picking_for_pos(self):
+        self.ensure_one()
         pickinglines = []
-        for line in picking.move_lines.filtered(lambda x: x.state != 'cancel'):
+        for line in self.move_lines.filtered(lambda x: x.state != 'cancel'):
             picking_line = {
                 'name': line.name,
                 'product_id': line.product_id.id,
@@ -60,16 +61,11 @@ class StockPicking(models.Model):
                 picking_line['discount'] = sale_order_line.discount
             pickinglines.append(picking_line)
         return {
-            'id': picking.id,
-            'name': picking.name,
-            'partner_id': picking.partner_id.id,
+            'id': self.id,
+            'name': self.name,
+            'partner_id': self.partner_id.id,
             'line_ids': pickinglines,
         }
-
-    @api.model
-    def load_picking_for_pos(self, picking_id):
-        picking = self.browse(picking_id)
-        return self._prepare_pos_order(picking)
 
     @api.multi
     def update_from_origin_picking(self, origin_picking):

--- a/pos_picking_load/static/src/js/pos_picking_load.js
+++ b/pos_picking_load/static/src/js/pos_picking_load.js
@@ -195,7 +195,7 @@ openerp.pos_picking_load = function(instance, local) {
         load_picking: function(origin_picking_id) {
             var self = this;
             var pickingModel = new instance.web.Model(this.model);
-            return pickingModel.call('load_picking_for_pos', [origin_picking_id])
+            return pickingModel.call('load_picking_for_pos', [[origin_picking_id]])
             .then(function (picking) {
                 self.current_picking_id = origin_picking_id;
                 self.current_picking_name = picking.name;


### PR DESCRIPTION
By wrapping the picking id in a list, the picking is instanciated on the server side when the api.multi decorator is applied to the method. The wrapping method that browses the picking is not needed anymore in that case.