### PR TITLE
[FIX] hw_telium_payment_terminal : pycountry now uses alpha_3 instead of letter

### DIFF
--- a/hw_telium_payment_terminal/controllers/main.py
+++ b/hw_telium_payment_terminal/controllers/main.py
@@ -128,7 +128,7 @@ class TeliumPaymentTerminalDriver(Thread):
             return False
         cur_iso_letter = payment_info_dict['currency_iso'].upper()
         try:
-            cur = pycountry.currencies.get(letter=cur_iso_letter)
+            cur = pycountry.currencies.get(alpha_3=cur_iso_letter)
             cur_numeric = str(cur.numeric)
         except:
             logger.error("Currency %s is not recognized" % cur_iso_letter)

--- a/hw_telium_payment_terminal/test-scripts/telium-test.py
+++ b/hw_telium_payment_terminal/test-scripts/telium-test.py
@@ -85,7 +85,7 @@ def prepare_data_to_send():
         return False
     cur_iso_letter = CURRENCY_ISO.upper()
     try:
-        cur = pycountry.currencies.get(letter=cur_iso_letter)
+        cur = pycountry.currencies.get(alpha_3=cur_iso_letter)
         cur_numeric = str(cur.numeric)
     except:
         print "Currency %s is not recognized" % cur_iso_letter


### PR DESCRIPTION
In pycountry >= 16.x ISO4217 now uses `alpha_3` instead of `letter` 