### PR TITLE
[10.0] pos_remove_pos_category: inherit the proper view of product.template

### DIFF
--- a/pos_remove_pos_category/views/pos_view.xml
+++ b/pos_remove_pos_category/views/pos_view.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="product_template_form_view" model="ir.ui.view">
-        <field name="name">product.template.form.inherit</field>
+        <field name="name">hide.pos_categ_id.product.template.form</field>
         <field name="model">product.template</field>
-        <field name="inherit_id" ref="product.product_template_form_view"/>
-        <field name="priority" eval="100"/>
+        <field name="inherit_id" ref="point_of_sale.product_template_form_view"/>
         <field name="arch" type="xml">
             <field name="pos_categ_id" position="attributes">
                 <attribute name="invisible">1</attribute>


### PR DESCRIPTION
inherit the proper view of product.template: the pos_categ_id field is introduced in the module "point_of_sale", not in the module "product" !