### PR TITLE
[fix] compability between pos_customer_display and pos_pricelist

### DIFF
--- a/pos_customer_display/__manifest__.py
+++ b/pos_customer_display/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'POS Customer Display',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Point Of Sale',
     'summary': 'Manage Customer Display device from POS front end',
     'author': "Aurélien DUMAINE,Akretion,Odoo Community Association (OCA)",

--- a/pos_customer_display/static/src/js/customer_display.js
+++ b/pos_customer_display/static/src/js/customer_display.js
@@ -203,9 +203,8 @@ odoo.define('pos_customer_display', function(require) {
             var res = OrderlineSuper.prototype.set_quantity.call(this, quantity);
             if (quantity != 'remove') {
                 var line = this;
-                if(this.selected)
-                {
-                	this.pos.prepare_text_customer_display('add_update_line', {'line': line});
+                if(this.selected){
+                    this.pos.prepare_text_customer_display('add_update_line', {'line': line});
                 }
             }
             return res;
@@ -215,9 +214,8 @@ odoo.define('pos_customer_display', function(require) {
             var res = OrderlineSuper.prototype.set_discount.call(this, discount);
             if (discount) {
                 var line = this;
-                if(this.selected)
-                {
-                	this.pos.prepare_text_customer_display('add_update_line', {'line': line});
+                if(this.selected){
+                    this.pos.prepare_text_customer_display('add_update_line', {'line': line});
                 }
             }
             return res;
@@ -226,9 +224,8 @@ odoo.define('pos_customer_display', function(require) {
         set_unit_price: function(price){
             var res = OrderlineSuper.prototype.set_unit_price.call(this, price);
             var line = this;
-            if(this.selected)
-            {
-            	this.pos.prepare_text_customer_display('add_update_line', {'line': line});
+            if(this.selected){
+                this.pos.prepare_text_customer_display('add_update_line', {'line': line});
             }
             return res;
         },

--- a/pos_customer_display/static/src/js/customer_display.js
+++ b/pos_customer_display/static/src/js/customer_display.js
@@ -203,7 +203,10 @@ odoo.define('pos_customer_display', function(require) {
             var res = OrderlineSuper.prototype.set_quantity.call(this, quantity);
             if (quantity != 'remove') {
                 var line = this;
-                this.pos.prepare_text_customer_display('add_update_line', {'line': line});
+                if(this.selected)
+                {
+                	this.pos.prepare_text_customer_display('add_update_line', {'line': line});
+                }
             }
             return res;
         },
@@ -212,7 +215,10 @@ odoo.define('pos_customer_display', function(require) {
             var res = OrderlineSuper.prototype.set_discount.call(this, discount);
             if (discount) {
                 var line = this;
-                this.pos.prepare_text_customer_display('add_update_line', {'line': line});
+                if(this.selected)
+                {
+                	this.pos.prepare_text_customer_display('add_update_line', {'line': line});
+                }
             }
             return res;
         },
@@ -220,7 +226,10 @@ odoo.define('pos_customer_display', function(require) {
         set_unit_price: function(price){
             var res = OrderlineSuper.prototype.set_unit_price.call(this, price);
             var line = this;
-            this.pos.prepare_text_customer_display('add_update_line', {'line': line});
+            if(this.selected)
+            {
+            	this.pos.prepare_text_customer_display('add_update_line', {'line': line});
+            }
             return res;
         },
 


### PR DESCRIPTION
hello,

with the pos_pricelist and pos_customer_display, when I open a new ticket, the POS floods the customer display, so we have all products show on this display.

I modify pos_pricelist to remove this bug.

