### PR TITLE
[FIX][8.0] pos_pricelist rule error

### DIFF
--- a/pos_pricelist/models/account_fiscal_position.py
+++ b/pos_pricelist/models/account_fiscal_position.py
@@ -9,4 +9,5 @@ class AccountFiscalPositionTax(models.Model):
     _inherit = "account.fiscal.position.tax"
 
     company_id = fields.Many2one(
-        related="position_id.company_id", string="Company")
+        related="position_id.company_id", string="Company",
+        store=True)


### PR DESCRIPTION
Set account.fiscal.position.tax company_id to store = True to avoid rule error.

FIX : https://github.com/OCA/pos/issues/112

CC : @pedrobaeza, @StefanRijnhart, @cubells