### PR TITLE
[FIX] remove unrelated code to pos_pricelist and fix #128

### DIFF
--- a/pos_pricelist/__openerp__.py
+++ b/pos_pricelist/__openerp__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'POS Pricelist',
-    'version': '8.0.1.3.0',
+    'version': '8.0.1.4.0',
     'category': 'Point Of Sale',
     'sequence': 1,
     'author': "Adil Houmadi @Taktik, "

--- a/pos_pricelist/static/src/js/models.js
+++ b/pos_pricelist/static/src/js/models.js
@@ -74,60 +74,6 @@ function pos_pricelist_models(instance, module) {
     });
 
     /**
-     * Extend the order
-     */
-    module.Order = module.Order.extend({
-        /**
-         * override this method to merge lines
-         * TODO : Need some refactoring in the standard POS to Do it better
-         * TODO : from line 73 till 85, we need to move this to another method
-         * @param product
-         * @param options
-         */
-        addProduct: function (product, options) {
-            options = options || {};
-            var attr = JSON.parse(JSON.stringify(product));
-            attr.pos = this.pos;
-            attr.order = this;
-            var line = new module.Orderline({}, {
-                pos: this.pos,
-                order: this,
-                product: product
-            });
-            var self = this;
-            var found = false;
-
-            if (options.quantity !== undefined) {
-                line.set_quantity(options.quantity);
-            }
-            if (options.price !== undefined) {
-                line.set_unit_price(options.price);
-            }
-            if (options.discount !== undefined) {
-                line.set_discount(options.discount);
-            }
-
-            var orderlines = [];
-            if (self.get('orderLines').models !== undefined) {
-                orderlines = self.get('orderLines').models;
-            }
-            for (var i = 0; i < orderlines.length; i++) {
-                var _line = orderlines[i];
-                if (_line && _line.can_be_merged_with(line) &&
-                    options.merge !== false) {
-                    _line.merge(line);
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                this.get('orderLines').add(line);
-            }
-            this.selectLine(this.getLastOrderline());
-        }
-    });
-
-    /**
      * Extend the Order line
      */
     var OrderlineParent = module.Orderline;


### PR DESCRIPTION
Hi all,

I was trying to investigate on the bug #128, and for the time being, the bug occurs on a fresh database with pos_pricelist installed.
the reason is the change with an overwrite of the function addProduct (without calling super)

Looking more deeply, I just realized that this function has nothing to do with pos_pricelist and allow to merge lines, even if it's not the last line.
this feature can be great, but has nothing to do with this module.

I so removed the full function : 
- it restore the default merge function;
- it fixes #128.

@imaralux : can you test ?
@AdilHoumadi, could you take a look ?

CC : @StefanRijnhart, @pablocm-aserti, @antespi 