### PR TITLE
[FIX] #159. pos_restaurant and pos_required_customer are incompatible

### DIFF
--- a/pos_customer_display/__openerp__.py
+++ b/pos_customer_display/__openerp__.py
@@ -22,7 +22,7 @@
 
 {
     'name': 'POS Customer Display',
-    'version': '9.0.0.1.0',
+    'version': '9.0.0.2.0',
     'category': 'Point Of Sale',
     'summary': 'Manage Customer Display device from POS front end',
     'description': """

--- a/pos_customer_required/__openerp__.py
+++ b/pos_customer_required/__openerp__.py
@@ -10,7 +10,7 @@
     'version': '9.0.1.0.0',
     'category': 'Point Of Sale',
     'summary': 'Point of Sale Require Customer',
-    'author': 'Apertoso NV, La Louve, Odoo Community Association (OCA)',
+    'author': 'Apertoso NV, La Louve, GRAP, Odoo Community Association (OCA)',
     'license': 'AGPL-3',
     'website': 'http://www.apertoso.be',
     'depends': [

--- a/pos_customer_required/__openerp__.py
+++ b/pos_customer_required/__openerp__.py
@@ -11,6 +11,7 @@
     'category': 'Point Of Sale',
     'summary': 'Point of Sale Require Customer',
     'author': 'Apertoso NV, La Louve, Odoo Community Association (OCA)',
+    'license': 'AGPL-3',
     'website': 'http://www.apertoso.be',
     'depends': [
         'point_of_sale',

--- a/pos_customer_required/i18n/fr.po
+++ b/pos_customer_required/i18n/fr.po
@@ -1,23 +1,19 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * pos_customer_required
-# 
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2016
-# leemannd <denis.leemann@camptocamp.com>, 2016
+#	* pos_customer_required
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-21 03:45+0000\n"
-"PO-Revision-Date: 2016-12-21 03:45+0000\n"
-"Last-Translator: leemannd <denis.leemann@camptocamp.com>, 2016\n"
-"Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
+"POT-Creation-Date: 2018-01-08 09:31+0000\n"
+"PO-Revision-Date: 2018-01-08 09:31+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: fr\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: \n"
 
 #. module: pos_customer_required
 #. openerp-web
@@ -29,23 +25,16 @@ msgstr "Une commande anonyme ne peut pas être confirmée"
 #. module: pos_customer_required
 #: code:addons/pos_customer_required/models/pos_make_payment.py:23
 #, python-format
-msgid ""
-"An anonymous order cannot be confirmed.\n"
+msgid "An anonymous order cannot be confirmed.\n"
 "Please select a customer for this order."
-msgstr ""
-"Une commande anonyme ne peut pas être confirmée\n"
+msgstr "Une commande anonyme ne peut pas être confirmée\n"
 "Sélectionnez un client pour cette commande."
 
 #. module: pos_customer_required
-#: code:addons/pos_customer_required/models/pos_order.py:33
+#: code:addons/pos_customer_required/models/pos_order.py:34
 #, python-format
 msgid "Customer is required for this order and is missing."
 msgstr "Un client est requis et manquant."
-
-#. module: pos_customer_required
-#: selection:pos.config,require_customer:0
-msgid "Optional"
-msgstr "Facultatif"
 
 #. module: pos_customer_required
 #. openerp-web
@@ -76,16 +65,10 @@ msgstr "Client requis"
 
 #. module: pos_customer_required
 #: model:ir.model.fields,help:pos_customer_required.field_pos_config_require_customer
-msgid ""
-"Require customer for orders in this point of sale:\n"
-"* 'Optional' (customer is optional);\n"
-"* 'Required before paying';\n"
-"* 'Required before starting the order';"
-msgstr ""
-"Client requis pour les commandes de ce terminal de point de vente:\n"
-"* 'Optionnel' (Le client est optionnel);\n"
-"* 'Le client est requis avant le payement';\n"
-"* 'Le client est requis avant de commencer la commande';"
+msgid "Require customer for orders in this point of sale.\n"
+" Let empty if your want to let customer field optional"
+msgstr "Client requis pour les commandes de ce terminal de ce point de vente.\n"
+" Ne pas renseigner le champ si vous souhaitez laisser le champ client optionel."
 
 #. module: pos_customer_required
 #: selection:pos.config,require_customer:0
@@ -99,14 +82,13 @@ msgstr "Requis avant de commencer la vente"
 
 #. module: pos_customer_required
 #: model:ir.model.fields,help:pos_customer_required.field_pos_order_require_customer
-msgid ""
-"True if a customer is required to begin the order.\n"
+msgid "True if a customer is required to begin the order.\n"
 "See the PoS Config to change this setting"
-msgstr ""
-"Vrai si un client est requis pour commencer une vente.\n"
+msgstr "Vrai si un client est requis pour commencer une vente.\n"
 "Voir la configuration du point de vente pour changer ce paramètre."
 
 #. module: pos_customer_required
 #: model:ir.model,name:pos_customer_required.model_pos_config
 msgid "pos.config"
 msgstr "pos.config"
+

--- a/pos_customer_required/models/pos_config.py
+++ b/pos_customer_required/models/pos_config.py
@@ -18,8 +18,8 @@ class PosConfig(models.Model):
     ]
 
     require_customer = fields.Selection(
-        selection=_REQUIRE_CUSTOMER_KEYS,
-        string='Require Customer',
+        selection=_REQUIRE_CUSTOMER_KEYS, required=True,
+        string='Require Customer', default='no',
         help="Require customer for orders in this point of sale:\n"
         "* 'Optional' (customer is optional);\n"
         "* 'Required before paying';\n"

--- a/pos_customer_required/models/pos_config.py
+++ b/pos_customer_required/models/pos_config.py
@@ -12,15 +12,11 @@ class PosConfig(models.Model):
     _inherit = 'pos.config'
 
     _REQUIRE_CUSTOMER_KEYS = [
-        ('no', 'Optional'),
         ('payment', 'Required before paying'),
         ('order', 'Required before starting the order'),
     ]
 
     require_customer = fields.Selection(
-        selection=_REQUIRE_CUSTOMER_KEYS, required=True,
-        string='Require Customer', default='no',
-        help="Require customer for orders in this point of sale:\n"
-        "* 'Optional' (customer is optional);\n"
-        "* 'Required before paying';\n"
-        "* 'Required before starting the order';")
+        selection=_REQUIRE_CUSTOMER_KEYS, string='Require Customer',
+        help="Require customer for orders in this point of sale.\n"
+        " Let empty if your want to let customer field optional")

--- a/pos_customer_required/models/pos_order.py
+++ b/pos_customer_required/models/pos_order.py
@@ -12,22 +12,23 @@ from openerp.tools.translate import _
 class PosOrder(models.Model):
     _inherit = 'pos.order'
 
+    require_customer = fields.Boolean(
+        compute='_compute_require_customer', string='Require customer',
+        help="True if a customer is required to begin the order.\n"
+        "See the PoS Config to change this setting")
+
     @api.multi
     @api.depends('session_id.config_id.require_customer')
-    def compute_require_customer(self):
+    def _compute_require_customer(self):
         for order in self:
             order.require_customer = (
                 order.session_id.config_id.require_customer == 'order')
 
-    require_customer = fields.Boolean(
-        compute='compute_require_customer', string='Require customer',
-        help="True if a customer is required to begin the order.\n"
-        "See the PoS Config to change this setting")
-
-    @api.one
+    @api.multi
     @api.constrains('partner_id', 'require_customer')
     def _check_partner(self):
-        if (self.session_id.config_id.require_customer == 'order' and
-                not self.partner_id):
-            raise exceptions.ValidationError(
-                _('Customer is required for this order and is missing.'))
+        for order in self:
+            if (order.session_id.config_id.require_customer == 'order' and
+                    not order.partner_id):
+                raise exceptions.ValidationError(
+                    _('Customer is required for this order and is missing.'))

--- a/pos_customer_required/static/src/js/pos_customer_required.js
+++ b/pos_customer_required/static/src/js/pos_customer_required.js
@@ -45,6 +45,7 @@ odoo.define('pos_customer_required.pos_customer_required', function (require) {
     var _show_screen_ = gui.Gui.prototype.show_screen;
     gui.Gui.prototype.show_screen = function(screen_name, params, refresh){
         if(this.pos.config.require_customer == 'order'
+                && this.pos.get('selectedOrder')
                 && !this.pos.get('selectedOrder').get_client()
                 && screen_name != 'clientlist'){
             // We call first the original screen, to avoid to break the

--- a/pos_customer_required/static/src/js/pos_customer_required.js
+++ b/pos_customer_required/static/src/js/pos_customer_required.js
@@ -19,8 +19,8 @@ odoo.define('pos_customer_required.pos_customer_required', function (require) {
 
     screens.PaymentScreenWidget.include({
         validate_order: function(options) {
-            if(this.pos.config.require_customer != 'no'
-                    && !this.pos.get('selectedOrder').get_client()){
+            if(this.pos.config.require_customer !== 'no' &&
+                    !this.pos.get('selectedOrder').get_client()){
                 this.gui.show_popup('error',{
                     'title': _t('An anonymous order cannot be confirmed'),
                     'body':  _t('Please select a customer for this order.'),
@@ -44,16 +44,17 @@ odoo.define('pos_customer_required.pos_customer_required', function (require) {
 
     var _show_screen_ = gui.Gui.prototype.show_screen;
     gui.Gui.prototype.show_screen = function(screen_name, params, refresh){
-        if(this.pos.config.require_customer == 'order'
-                && this.pos.get('selectedOrder')
-                && !this.pos.get('selectedOrder').get_client()
-                && screen_name != 'clientlist'){
+        var new_screen_name = screen_name;
+        if(this.pos.config.require_customer === 'order' &&
+                this.pos.get('selectedOrder') &&
+                !this.pos.get('selectedOrder').get_client() &&
+                screen_name !== 'clientlist'){
             // We call first the original screen, to avoid to break the
             // 'previous screen' mecanism
             _show_screen_.call(this, screen_name, params, refresh);
-            screen_name = 'clientlist';
+            new_screen_name = 'clientlist';
         }
-        _show_screen_.call(this, screen_name, params, refresh);
+        _show_screen_.call(this, new_screen_name, params, refresh);
     };
 
 });

--- a/pos_customer_required/static/src/js/pos_customer_required.js
+++ b/pos_customer_required/static/src/js/pos_customer_required.js
@@ -19,7 +19,7 @@ odoo.define('pos_customer_required.pos_customer_required', function (require) {
 
     screens.PaymentScreenWidget.include({
         validate_order: function(options) {
-            if(this.pos.config.require_customer !== 'no' &&
+            if(this.pos.config.require_customer !== false &&
                     !this.pos.get('selectedOrder').get_client()){
                 this.gui.show_popup('error',{
                     'title': _t('An anonymous order cannot be confirmed'),


### PR DESCRIPTION
Fix : #159.

Trivial fix to make pos_customer_required and pos_restaurant compatible.

(if pos_restaurant is installed, there is no pos order in `this.pos.get('selectedOrder')` when the PoS is starting. (only when a table is selected).

With this patch, (and if required setting is "order") first odoo will ask the place, and just after, the name of the customer.

@damendieta : could you test ?

CC reviewers of the first PR : @pedrobaeza, @invitu, @JosDeGraeve, @StefanRijnhart 

regards.
