### PR TITLE
[FIX] remove outdated dependencies

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,1 +1,0 @@
-pos https://github.com/akretion/pos.git 10.0-add-pos_backend_communication


### PR DESCRIPTION
this file add an outdated dependency to a non OCA repository. introduced by 663bf4be0d8fd4a016e9d7b90832f52e36f5551f. (PR #227)
This dependency is not needed as #226 has been merged.