### PR TITLE
[10.0][IMP] pos_payment_terminal: receive transaction refs

### DIFF
--- a/pos_payment_terminal/models/__init__.py
+++ b/pos_payment_terminal/models/__init__.py
@@ -2,3 +2,4 @@
 
 from . import pos_config
 from . import account_journal
+from . import pos_order

--- a/pos_payment_terminal/models/pos_order.py
+++ b/pos_payment_terminal/models/pos_order.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# © 2018 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from collections import defaultdict
+import logging
+
+from odoo import models, api
+
+_logger = logging.getLogger(__name__)
+
+
+class PosOrder(models.Model):
+    _inherit = 'pos.order'
+
+    @api.model
+    def _match_transactions_to_payments(self, pos_order):
+        payments = pos_order['statement_ids']
+        transactions = pos_order['transactions']
+        card_journals = self.env['account.journal'].search([
+            ('id', 'in', [p[2]['journal_id'] for p in payments]),
+            ('payment_mode', '!=', False),
+        ])
+        card_payments = [record[2] for record in payments
+                         if record[2]['journal_id'] in card_journals.ids]
+
+        def amount_cents(obj):
+            if 'amount_cents' in obj:
+                return obj['amount_cents']
+            else:
+                return int(round(obj['amount'] * 100))
+
+        try:
+            for payment, transaction in match(card_payments, transactions,
+                                              key=amount_cents):
+                payment['note'] = transaction['reference']
+        except ValueError as e:
+            _logger.error("Error matching transactions to payments: %s",
+                          e.args[0])
+
+    def _process_order(self, pos_order):
+        if pos_order.get('transactions'):
+            self._match_transactions_to_payments(pos_order)
+        return super(PosOrder, self)._process_order(pos_order)
+
+
+def group_by(lists, key):
+    count = range(len(lists))
+    d = defaultdict(lambda: tuple([[] for _ in count]))
+    for i, objects in enumerate(lists):
+        for obj in objects:
+            d[key(obj)][i].append(obj)
+    return d
+
+
+def match(al, bl, key):
+    for key, groups in group_by((al, bl), key).items():
+        if groups[0] and len(groups[0]) != len(groups[1]):
+            raise ValueError("Missing value for {!r}".format(key))
+        for val in zip(*groups):
+            yield val

--- a/pos_payment_terminal/models/pos_order.py
+++ b/pos_payment_terminal/models/pos_order.py
@@ -16,6 +16,9 @@ class PosOrder(models.Model):
     def _match_transactions_to_payments(self, pos_order):
         payments = pos_order['statement_ids']
         transactions = pos_order['transactions']
+        pos_session = self.env['pos.session'].browse(
+            pos_order['pos_session_id'])
+        currency_digits = pos_session.currency_id.decimal_places
         card_journals = self.env['account.journal'].search([
             ('id', 'in', [p[2]['journal_id'] for p in payments]),
             ('payment_mode', '!=', False),
@@ -27,7 +30,7 @@ class PosOrder(models.Model):
             if 'amount_cents' in obj:
                 return obj['amount_cents']
             else:
-                return int(round(obj['amount'] * 100))
+                return int(round(obj['amount'] * pow(10, currency_digits)))
 
         try:
             for payment, transaction in match(card_payments, transactions,

--- a/pos_payment_terminal/static/src/js/pos_payment_terminal.js
+++ b/pos_payment_terminal/static/src/js/pos_payment_terminal.js
@@ -38,16 +38,13 @@ odoo.define('pos_payment_terminal.pos_payment_terminal', function (require) {
 
                     var transactions = drivers[driver_name].latest_transactions;
                     if(!!transactions && transactions.hasOwnProperty(order.uid)) {
+                        var previous_transactions = order.transactions;
                         order.transactions = transactions[order.uid];
-
-                        var order_total = Math.round(order.get_total_with_tax() * 100.0);
-                        var paid_total = order.transactions.map(function(t) {
-                            return t.amount_cents;
-                        }).reduce(function add(a, b) {
-                            return a + b;
-                        }, 0);
-
-                        if(order_total === paid_total) {
+                        var has_new_transactions = (
+                            !previous_transactions ||
+                            previous_transactions.length < order.transactions.length
+                        );
+                        if(has_new_transactions && order.is_paid()) {
                             paymentwidget.validate_order();
                         }
                     }

--- a/pos_payment_terminal/tests/__init__.py
+++ b/pos_payment_terminal/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_transactions

--- a/pos_payment_terminal/tests/test_transactions.py
+++ b/pos_payment_terminal/tests/test_transactions.py
@@ -2,10 +2,10 @@
 # Copyright (C) 2018-TODAY ACSONE SA/NV (<https://www.acsone.eu>).
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-import odoo
+from odoo.addons.point_of_sale.tests.common import TestPointOfSaleCommon
 
 
-class TestTransactions(odoo.tests.TransactionCase):
+class TestTransactions(TestPointOfSaleCommon):
 
     def test_matching(self):
         card_journal_id = self.env['account.journal'].create({
@@ -16,6 +16,7 @@ class TestTransactions(odoo.tests.TransactionCase):
         }).id
         cash_journal_id = 0
         pos_order = {
+            'pos_session_id': self.pos_order_session0.id,
             'statement_ids': [
                 (0, 0, {
                     'name': 'Payment1',

--- a/pos_payment_terminal/tests/test_transactions.py
+++ b/pos_payment_terminal/tests/test_transactions.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018-TODAY ACSONE SA/NV (<https://www.acsone.eu>).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import odoo
+
+
+class TestTransactions(odoo.tests.TransactionCase):
+
+    def test_matching(self):
+        card_journal_id = self.env['account.journal'].create({
+            'name': 'Card Journal',
+            'code': 'CARD',
+            'type': 'bank',
+            'payment_mode': 'card',
+        }).id
+        cash_journal_id = 0
+        pos_order = {
+            'statement_ids': [
+                (0, 0, {
+                    'name': 'Payment1',
+                    'amount': 45.2,
+                    'journal_id': card_journal_id,
+                }),
+                (0, 0, {
+                    'name': 'Payment2',
+                    'amount': 10.5,
+                    'journal_id': card_journal_id,
+                }),
+                (0, 0, {
+                    'name': 'Payment3',
+                    'amount': 22.0,
+                    'journal_id': cash_journal_id,
+                }),
+            ],
+            'transactions': [
+                {
+                    'reference': 'ABCDE',
+                    'amount_cents': 1050,
+                },
+                {
+                    'reference': 'XPTO',
+                    'amount_cents': 4520,
+                },
+            ]
+        }
+        self.env['pos.order']._match_transactions_to_payments(pos_order)
+        self.assertEquals(pos_order['statement_ids'][0][2]['note'], 'XPTO')
+        self.assertEquals(pos_order['statement_ids'][1][2]['note'], 'ABCDE')


### PR DESCRIPTION
Provide a mechanism to send the order UID to the payment terminal, which can then pass the transaction reference generated by the payment provider back to Odoo, and which is then added to the order payment lines. This allows their subsequent reconciliation. The order is also automatically validated when the payment finishes.

This is used by the [new Adyen driver](https://github.com/akretion/pywebdriver/pull/25), but the mechanism is generic.