### PR TITLE
[FIX] fixes currencies with decimals <>2

### DIFF
--- a/hw_telium_payment_terminal/controllers/main.py
+++ b/hw_telium_payment_terminal/controllers/main.py
@@ -129,6 +129,8 @@ class TeliumPaymentTerminalDriver(Thread):
                 "The payment mode '%s' is not supported"
                 % payment_info_dict['payment_mode'])
             return False
+        cur_decimals = payment_info_dict['currency_decimals']
+        cur_fact = 10**cur_decimals
         cur_iso_letter = payment_info_dict['currency_iso'].upper()
         try:
             cur = pycountry.currencies.get(alpha_3=cur_iso_letter)
@@ -145,7 +147,7 @@ class TeliumPaymentTerminalDriver(Thread):
             'private': ' ' * 10,
             'delay': 'A011',
             'auto': 'B010',
-            'amount_msg': ('%.0f' % (amount * 100)).zfill(8),
+            'amount_msg': ('%.0f' % (amount * cur_fact)).zfill(8),
         }
         return data
 


### PR DESCRIPTION
This PR has to be merged at the same time as https://github.com/OCA/pos/pull/196
because hw_* have been removed from 10.0 branch

Odoo server runs v10.0 and posbox runs v8.0 (https://github.com/OCA/pos/pull/231 and https://github.com/OCA/pos/pull/230)