### PR TITLE
[FIX] pos_pricelist: Use lower-version date comparison

### DIFF
--- a/pos_pricelist/__manifest__.py
+++ b/pos_pricelist/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'POS Pricelist',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Point Of Sale',
     'author': "Tecnativa, "
               "Odoo SA, "

--- a/pos_pricelist/static/src/js/models.js
+++ b/pos_pricelist/static/src/js/models.js
@@ -145,8 +145,8 @@ odoo.define("pos_pricelist.models", function (require) {
                 return (! item.product_tmpl_id || item.product_tmpl_id[0] === self.product_tmpl_id) &&
                         (! item.product_id || item.product_id[0] === self.id) &&
                         (! item.categ_id || _.contains(category_ids, item.categ_id[0])) &&
-                        (! item.date_start || moment(item.date_start).isSameOrBefore(date)) &&
-                        (! item.date_end || moment(item.date_end).isSameOrAfter(date));
+                        (! item.date_start || moment(item.date_start) <= date) &&
+                        (! item.date_end || moment(item.date_end) >= date);
             });
 
             var price = self.lst_price;


### PR DESCRIPTION
[The removed function was introduced in momentjs in version 2.11.0](https://momentjs.com/docs/#/query/is-same-or-before/), but [Odoo 10.0 ships 2.8.1](https://github.com/odoo/odoo/blob/b2c321fd1f86a8cb6329e75e6306a657caf17987/addons/web/static/lib/moment/moment.js#L2), so I'm using a different comparison system here that should yield the same results without exceptions.

@Tecnativa