### PR TITLE
[8.0][fix] pos_pricelist

### DIFF
--- a/pos_pricelist/__openerp__.py
+++ b/pos_pricelist/__openerp__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'POS Pricelist',
-    'version': '8.0.1.4.0',
+    'version': '8.0.1.5.0',
     'category': 'Point Of Sale',
     'sequence': 1,
     'author': "Adil Houmadi @Taktik, "

--- a/pos_pricelist/i18n/fr.po
+++ b/pos_pricelist/i18n/fr.po
@@ -8,32 +8,32 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pos (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-24 11:35+0000\n"
-"PO-Revision-Date: 2017-09-22 22:56+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: French (http://www.transifex.com/oca/OCA-pos-8-0/language/fr/)\n"
+"POT-Creation-Date: 2018-03-02 16:22+0000\n"
+"PO-Revision-Date: 2018-03-02 16:22+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: fr\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: \n"
 
 #. module: pos_pricelist
-#: field:pos.order.tax,amount:0 view:website:point_of_sale.report_receipt
+#: field:pos.order.tax,amount:0
+#: view:website:point_of_sale.report_receipt
 msgid "Amount"
 msgstr "Montant"
 
 #. module: pos_pricelist
 #. openerp-web
 #: code:addons/pos_pricelist/static/src/js/models.js:402
+#: code:addons/pos_pricelist/static/src/js/models.js:422
 #, python-format
-msgid ""
-"At least one pricelist has no active version ! Please create or activate "
-"one."
-msgstr ""
+msgid "At least one pricelist has no active version ! Please create or activate one."
+msgstr "Au moins une liste de prix n'a pas de version active ! Veuillez en créer ou en activer une."
 
 #. module: pos_pricelist
-#: field:pos.order.tax,base:0 view:website:point_of_sale.report_receipt
+#: field:pos.order.tax,base:0
+#: view:website:point_of_sale.report_receipt
 msgid "Base"
 msgstr "Base"
 
@@ -60,10 +60,12 @@ msgstr "Nom à afficher"
 #. module: pos_pricelist
 #: help:pos.config,display_price_with_taxes:0
 msgid "Display Prices with taxes on POS"
-msgstr ""
+msgstr "Afficher les prix TTC sur le point de vente"
 
 #. module: pos_pricelist
+#: code:addons/pos_pricelist/models/pos_order_patch.py:26
 #: code:addons/pos_pricelist/models/pos_order_patch.py:28
+#: code:addons/pos_pricelist/models/pos_order_patch.py:152
 #: code:addons/pos_pricelist/models/pos_order_patch.py:154
 #, python-format
 msgid "Error!"
@@ -95,29 +97,41 @@ msgid "Lines of Point of Sale"
 msgstr "Lignes de Points de Vente"
 
 #. module: pos_pricelist
+#. openerp-web
+#: code:addons/pos_pricelist/static/src/xml/pos.xml:46
+#, python-format
+msgid "N/A"
+msgstr "N/A"
+
+#. module: pos_pricelist
 #: field:pos.order.tax,pos_order:0
 msgid "POS Order"
-msgstr ""
+msgstr "Vente"
 
 #. module: pos_pricelist
 #: model:product.template,name:pos_pricelist.pos_product_product_1_product_template
 msgid "POS Product 1"
-msgstr ""
+msgstr "POS Product 1"
 
 #. module: pos_pricelist
 #: model:product.template,name:pos_pricelist.pos_product_product_2_product_template
 msgid "POS Product 2"
-msgstr ""
+msgstr "POS Product 2"
 
 #. module: pos_pricelist
 #: model:product.template,name:pos_pricelist.pos_product_product_3_product_template
 msgid "POS Product 3"
-msgstr ""
+msgstr "POS Product 3"
 
 #. module: pos_pricelist
 #: model:product.template,name:pos_pricelist.pos_product_product_4_product_template
 msgid "POS Product 4"
-msgstr ""
+msgstr "POS Product 4"
+
+#. module: pos_pricelist
+#: model:ir.model,name:pos_pricelist.model_res_partner
+msgid "Partner"
+msgstr "Partenaire"
 
 #. module: pos_pricelist
 #: view:pos.order:pos_pricelist.view_pos_pos_form
@@ -125,38 +139,52 @@ msgid "Payments"
 msgstr "Paiements"
 
 #. module: pos_pricelist
+#: code:addons/pos_pricelist/models/pos_order_patch.py:152
 #: code:addons/pos_pricelist/models/pos_order_patch.py:154
 #, python-format
 msgid "Please define income account for this product: \"%s\" (id:%d)."
-msgstr ""
+msgstr "Veuillez définir un compte de revenu pour cet article : \"%s\" (id. : %d)"
 
 #. module: pos_pricelist
 #: model:ir.model,name:pos_pricelist.model_pos_order
 msgid "Point of Sale"
-msgstr "Point de vente"
+msgstr "Point de Vente"
 
 #. module: pos_pricelist
 #: field:pos.config,display_price_with_taxes:0
 msgid "Price With Taxes"
-msgstr ""
+msgstr "Prix TTC"
+
+#. module: pos_pricelist
+#. openerp-web
+#: code:addons/pos_pricelist/static/src/xml/pos.xml:41
+#: code:addons/pos_pricelist/static/src/xml/pos.xml:55
+#, python-format
+msgid "Pricelist"
+msgstr "Liste de prix"
 
 #. module: pos_pricelist
 #. openerp-web
 #: code:addons/pos_pricelist/static/src/js/models.js:401
+#: code:addons/pos_pricelist/static/src/js/models.js:421
 #, python-format
 msgid "Pricelist Error"
-msgstr ""
+msgstr "Erreur de liste de prix"
 
 #. module: pos_pricelist
+#: code:addons/pos_pricelist/models/pos_order_patch.py:26
 #: code:addons/pos_pricelist/models/pos_order_patch.py:28
 #, python-format
 msgid "Selected orders do not have the same session!"
-msgstr ""
+msgstr "Les commandes sélectionnées n'ont pas la même session !"
 
 #. module: pos_pricelist
+#: code:addons/pos_pricelist/models/pos_order_patch.py:188
 #: code:addons/pos_pricelist/models/pos_order_patch.py:190
+#: code:addons/pos_pricelist/models/pos_order_patch.py:205
 #: code:addons/pos_pricelist/models/pos_order_patch.py:207
-#: field:pos.order.tax,tax:0 view:website:point_of_sale.report_receipt
+#: field:pos.order.tax,tax:0
+#: view:website:point_of_sale.report_receipt
 #, python-format
 msgid "Tax"
 msgstr "Taxe"
@@ -164,10 +192,11 @@ msgstr "Taxe"
 #. module: pos_pricelist
 #: field:pos.order.tax,name:0
 msgid "Tax Description"
-msgstr ""
+msgstr "Description de la taxe"
 
 #. module: pos_pricelist
-#: view:pos.order:pos_pricelist.view_pos_pos_form field:pos.order,taxes:0
+#: view:pos.order:pos_pricelist.view_pos_pos_form
+#: field:pos.order,taxes:0
 #: field:pos.order.line,tax_ids:0
 msgid "Taxes"
 msgstr "Taxes"
@@ -175,21 +204,23 @@ msgstr "Taxes"
 #. module: pos_pricelist
 #: model:ir.model,name:pos_pricelist.model_account_fiscal_position_tax
 msgid "Taxes Fiscal Position"
-msgstr ""
+msgstr "Position fiscale des taxes"
 
 #. module: pos_pricelist
 #: view:pos.order:pos_pricelist.view_pos_pos_form
 msgid "Taxes detail"
-msgstr ""
+msgstr "Détail des taxes"
 
 #. module: pos_pricelist
+#: code:addons/pos_pricelist/models/pos_order_patch.py:117
 #: code:addons/pos_pricelist/models/pos_order_patch.py:119
 #, python-format
 msgid "The POS order must have lines when calling this method"
-msgstr ""
+msgstr "Le point de vente doit avoir des lignes lors de l'appel à cette méthode"
 
 #. module: pos_pricelist
+#: code:addons/pos_pricelist/models/pos_order_patch.py:218
 #: code:addons/pos_pricelist/models/pos_order_patch.py:220
 #, python-format
 msgid "Trade Receivables"
-msgstr ""
+msgstr "Marchandises à recevoir"

--- a/pos_pricelist/models/__init__.py
+++ b/pos_pricelist/models/__init__.py
@@ -7,3 +7,4 @@ from . import account_fiscal_position
 from . import pos_pricelist
 from . import point_of_sale
 from . import pos_order_patch
+from . import res_partner

--- a/pos_pricelist/models/point_of_sale.py
+++ b/pos_pricelist/models/point_of_sale.py
@@ -91,6 +91,12 @@ class PosOrder(models.Model):
                             inverse_name='pos_order', readonly=True)
 
     @api.model
+    def _order_fields(self, ui_order):
+        res = super(PosOrder, self)._order_fields(ui_order)
+        res.update({'pricelist_id': ui_order['pricelist_id']})
+        return res
+
+    @api.model
     def _amount_line_tax(self, line):
         price = line.price_unit * (1 - (line.discount or 0.0) / 100.0)
         taxes = line.tax_ids.compute_all(

--- a/pos_pricelist/models/point_of_sale.py
+++ b/pos_pricelist/models/point_of_sale.py
@@ -84,6 +84,7 @@ class PosOrderLine(models.Model):
             res['value']['tax_ids'] = product.taxes_id.ids
         return res
 
+
 class PosOrder(models.Model):
     _inherit = "pos.order"
 

--- a/pos_pricelist/models/point_of_sale.py
+++ b/pos_pricelist/models/point_of_sale.py
@@ -73,6 +73,16 @@ class PosOrderLine(models.Model):
     price_subtotal = fields.Float(compute="_amount_line_all", store=True)
     price_subtotal_incl = fields.Float(compute="_amount_line_all", store=True)
 
+    @api.multi
+    def onchange_product_id(
+            self, pricelist, product_id, qty=0, partner_id=False):
+        product_obj = self.env['product.product']
+        res = super(PosOrderLine, self).onchange_product_id(
+            pricelist, product_id, qty=qty, partner_id=partner_id)
+        if product_id:
+            product = product_obj.browse(product_id)
+            res['value']['tax_ids'] = product.taxes_id.ids
+        return res
 
 class PosOrder(models.Model):
     _inherit = "pos.order"

--- a/pos_pricelist/models/res_partner.py
+++ b/pos_pricelist/models/res_partner.py
@@ -1,0 +1,20 @@
+# coding: utf-8
+# Copyright (C) 2018 - Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, models
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    @api.model
+    def create_from_ui(self, partner):
+        if 'property_product_pricelist' in partner:
+            pricelist_id_str = partner.get('property_product_pricelist')
+            if pricelist_id_str:
+                partner['property_product_pricelist'] = int(pricelist_id_str)
+            else:
+                partner['property_product_pricelist'] = False
+        return super(ResPartner, self).create_from_ui(partner)

--- a/pos_pricelist/static/src/js/models.js
+++ b/pos_pricelist/static/src/js/models.js
@@ -74,6 +74,24 @@ function pos_pricelist_models(instance, module) {
     });
 
     /**
+     * Extend the Order
+     */
+    var moduleOrderParent = module.Order;
+    module.Order = module.Order.extend({
+        export_as_JSON: function() {
+            var order = moduleOrderParent.prototype.export_as_JSON.apply(this, arguments);
+            partner = this.get_client();
+            if (partner && partner.property_product_pricelist) {
+                pricelist_id = partner.property_product_pricelist[0];
+            } else {
+                pricelist_id = this.pos.config.pricelist_id[0];
+            }
+            order['pricelist_id'] =  pricelist_id;
+            return order;
+        },
+    });
+
+    /**
      * Extend the Order line
      */
     var OrderlineParent = module.Orderline;

--- a/pos_pricelist/static/src/xml/pos.xml
+++ b/pos_pricelist/static/src/xml/pos.xml
@@ -34,4 +34,36 @@
             </t>
         </t>
     </t>
+
+    <t t-extend="ClientDetails">
+        <t t-jquery=".client-details-right" t-operation="append">
+            <div class='client-detail'>
+                <span class='label'>Pricelist</span>
+                <t t-if='partner.property_product_pricelist'>
+                    <span class='detail pricelist'><t t-esc='partner.property_product_pricelist[1]'/></span>
+                </t>
+                <t t-if='!partner.property_product_pricelist'>
+                    <span class='detail pricelist empty'>N/A</span>
+                </t>
+            </div>
+        </t>
+    </t>
+
+    <t t-extend="ClientDetailsEdit">
+        <t t-jquery=".client-details-right" t-operation="append">
+            <div class='client-detail'>
+                <span class='label'>Pricelist</span>
+                <select class='detail client-pricelist_id needsclick' name='property_product_pricelist'>
+                    <option value=''></option>
+                    <t t-foreach='widget.pos.db.pricelist_by_id' t-as='pricelist_id'>
+                        <t t-set="pricelist" t-value="widget.pos.db.pricelist_by_id[pricelist_id]"/>
+                        <option t-att-value='pricelist.id' t-att-selected="partner.property_product_pricelist ? ((pricelist.id === partner.property_product_pricelist[0]) ? true : undefined) : undefined">
+                            <t t-esc='pricelist.name'/>
+                        </option>
+                    </t>
+                </select>
+            </div>
+        </t>
+    </t>
+
 </templates>


### PR DESCRIPTION
Before the PR

1. when adding a pos.order.line in the classical UI (not tactile), pos.order.line doesn't have taxes. This is problematical when user create / update refunds.
2. when user create a pos order (in the PoS UI) with a customer that have a specific pricelist, the pricelist is not saved in the pos.order
3. It is not possible to create / update the pricelist of a customer.

This PR fixes those 3 bugs.

Regards.
