### PR TITLE
[10][FIX] Protect crash at runtime if oca-decorator not installed

### DIFF
--- a/pos_pricelist/__init__.py
+++ b/pos_pricelist/__init__.py
@@ -2,8 +2,9 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from .hooks import post_init_hook
-
 try:
     from . import models
-except NameError: # pragma: no-cover
-    pass
+except ImportError:  # pragma: no-cover
+    import logging
+    _logger = logging.getLogger(__name__)
+    _logger.warn("Missing dependency", exc_info=True)

--- a/pos_pricelist/__init__.py
+++ b/pos_pricelist/__init__.py
@@ -2,4 +2,8 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from .hooks import post_init_hook
-from . import models
+
+try:
+    from . import models
+except NameError: # pragma: no-cover
+    pass

--- a/pos_pricelist/models/pos_config.py
+++ b/pos_pricelist/models/pos_config.py
@@ -4,14 +4,10 @@
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+from oca.decorators import foreach
 import logging
 
 _logger = logging.getLogger(__name__)
-
-try:
-    from oca.decorators import foreach
-except ImportError:  # pragma: no-cover
-    _logger.warn("Missing dependency", exc_info=True)
 
 
 class PosConfig(models.Model):

--- a/pos_pricelist/models/pos_config.py
+++ b/pos_pricelist/models/pos_config.py
@@ -4,7 +4,7 @@
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
-from oca.decorators import foreach
+from oca.decorators import foreach  # pylint: disable=W7935
 import logging
 
 _logger = logging.getLogger(__name__)


### PR DESCRIPTION
Fail silently if @foreach not loaded

Fixes #249 