### PR TITLE
Fix account-payment's github repo url

### DIFF
--- a/pos_session_pay_invoice/README.rst
+++ b/pos_session_pay_invoice/README.rst
@@ -12,7 +12,7 @@ Installation
 ============
 
 * In order to install this module, you will need to install first the
-  module 'account_cash_invoice', available in https://github.com/OCA/account-payment/11.0
+  module 'account_cash_invoice', available in https://github.com/OCA/account-payment/
 
 Configuration
 =============


### PR DESCRIPTION
The url of github repo for account-payment was wrong. 