### PR TITLE
[8.0][FIX] Error pos_pricelist compare Dates 

### DIFF
--- a/pos_pricelist/static/src/js/models.js
+++ b/pos_pricelist/static/src/js/models.js
@@ -331,6 +331,7 @@ function pos_pricelist_models(instance, module) {
          */
         find_valid_pricelist_version: function (db, pricelist_id) {
             var date = new Date();
+            date = new Date(date.getFullYear(), date.getMonth(), date.getDate())
             var version = false;
             var pricelist = db.pricelist_by_id[pricelist_id];
             for (var i = 0, len = pricelist.version_id.length; i < len; i++) {

--- a/pos_pricelist/static/src/js/models.js
+++ b/pos_pricelist/static/src/js/models.js
@@ -337,9 +337,9 @@ function pos_pricelist_models(instance, module) {
             for (var i = 0, len = pricelist.version_id.length; i < len; i++) {
                 var v = db.pricelist_version_by_id[pricelist.version_id[i]];
                 if (((v.date_start == false)
-                    || (new Date(v.date_start) <= date)) &&
+                    || (new Date(v.date_start.split('-')) <= date)) &&
                     ((v.date_end == false)
-                    || (new Date(v.date_end) >= date))) {
+                    || (new Date(v.date_end.split('-')) >= date))) {
                     version = v;
                     break;
                 }


### PR DESCRIPTION
Error pos_pricelist compare Dates in function find_valid_pricelist_version.

The var date that initialize with new Date(), and this have the date and the time in the moment of the creation. If you have a pricelist with a date_start or date_end those dates only have the date, and the times inicilice to 0. If you compare for example date_end (Thu Sep 20 2018 00:00:00) >= date (Thu Sep 20 2018 14:24:56), the comparison is wrong, when this has to be correct.

Regards