### PR TITLE
[10][FIX] pos_payment_terminal fix js loading

### DIFF
--- a/pos_payment_terminal/__manifest__.py
+++ b/pos_payment_terminal/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'POS Payment Terminal',
-    'version': '10.0.0.1.0',
+    'version': '10.0.0.1.1',
     'category': 'Point Of Sale',
     'summary': 'Manage Payment Terminal device from POS front end',
     'author': "Aurélien DUMAINE,Akretion,Odoo Community Association (OCA)",

--- a/pos_payment_terminal/views/pos_payment_terminal_template.xml
+++ b/pos_payment_terminal/views/pos_payment_terminal_template.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <template id="assets" inherit_id="point_of_sale.assets_backend" name="pos_payment_terminal assets">
-      <xpath expr="." position="inside">
+    <template id="assets" inherit_id="point_of_sale.assets" name="pos_payment_terminal assets">
+        <xpath expr="." position="inside">
             <script type="text/javascript" src="/pos_payment_terminal/static/src/js/pos_payment_terminal.js"></script>
-          <link rel="stylesheet" href="/pos_payment_terminal/static/src/css/pos_payment_terminal.css" />
+            <link rel="stylesheet" href="/pos_payment_terminal/static/src/css/pos_payment_terminal.css" />
       </xpath>
     </template>
 


### PR DESCRIPTION
Without the fix : warnings will be displayed in the browser's console for backend pages.