### PR TITLE
[FIX] pos_pricelist do not load unexisting field #131

### DIFF
--- a/pos_pricelist/static/src/js/models.js
+++ b/pos_pricelist/static/src/js/models.js
@@ -746,7 +746,7 @@ function pos_pricelist_models(instance, module) {
                         'pricelist_id',
                         'date_start',
                         'date_end',
-                        'items'],
+                        ],
                     domain: function (self) {
                         var pricelist_ids = _.map(_.keys(self.db.pricelist_by_id), function(el){return parseInt(el)});
                         return [


### PR DESCRIPTION
Remove a field that doesn't exist in the model product.pricelist.version and so that create warning in logs, each time PoS is loaded.

```
WARNING product.pricelist.version.read() with unknown field 'items'
```

Thanks for your review for this trivial patch.

regards.

FIX : https://github.com/OCA/pos/issues/131