### PR TITLE
[FIX] display /kg for to_weight products

### DIFF
--- a/pos_pricelist/static/src/js/models.js
+++ b/pos_pricelist/static/src/js/models.js
@@ -577,7 +577,8 @@ function pos_pricelist_models(instance, module) {
                         price = this.pos_widget.format_currency(price);
                         if (k == 0) {
                             if (product.to_weight) {
-                                $(product_ui).find('.price-tag').html(price + '/Kg');
+                                $(product_ui).find('.price-tag').html(price
+                                  + this.pos_widget.pos.units_by_id[product.uom_id[0]].name);
                             } else {
                                 $(product_ui).find('.price-tag').html(price);
                             }

--- a/pos_pricelist/static/src/js/models.js
+++ b/pos_pricelist/static/src/js/models.js
@@ -578,7 +578,7 @@ function pos_pricelist_models(instance, module) {
                         if (k == 0) {
                             if (product.to_weight) {
                                 $(product_ui).find('.price-tag').html(price
-                                  + this.pos_widget.pos.units_by_id[product.uom_id[0]].name);
+                                  + ' / ' + this.pos_widget.pos.units_by_id[product.uom_id[0]].name);
                             } else {
                                 $(product_ui).find('.price-tag').html(price);
                             }

--- a/pos_pricelist/static/src/js/models.js
+++ b/pos_pricelist/static/src/js/models.js
@@ -576,7 +576,11 @@ function pos_pricelist_models(instance, module) {
                             || 0, this.pos.dp['Product Price']);
                         price = this.pos_widget.format_currency(price);
                         if (k == 0) {
-                            $(product_ui).find('.price-tag').html(price);
+                            if (product.to_weight) {
+                                $(product_ui).find('.price-tag').html(price + '/Kg');
+                            } else {
+                                $(product_ui).find('.price-tag').html(price);
+                            }
                         }
                         prices_displayed += qty
                             + 'x &#8594; ' + price + '<br/>';


### PR DESCRIPTION
Trivial patch. restore the display of '/kg' for to_weight product that is hidden where pos_pricelist is installed.

before this patch :

![image](https://user-images.githubusercontent.com/3407482/49457974-2b8fff80-f7ec-11e8-9ec7-eaa1d6b5de8e.png)


After this patch :

![image](https://user-images.githubusercontent.com/3407482/49457921-14e9a880-f7ec-11e8-9280-794936c05b80.png)

CC : @quentinDupont 
