### PR TITLE
[FIX] Update has_image when you change product_product image

### DIFF
--- a/pos_default_empty_image/models/product_product.py
+++ b/pos_default_empty_image/models/product_product.py
@@ -8,7 +8,7 @@ class ProductProduct(models.Model):
     _inherit = ['product.product']
 
     @api.multi
-    @api.depends('image')
+    @api.depends('image', 'image_medium')
     def _compute_has_image(self):
         for record in self:
             record.has_image = bool(record.image)


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

In the product_product form view, if you change the image, it's not loaded in the pos.

**Current behavior before PR:**

Has_image is not triggered when you changed the image_medium in form view 

**Desired behavior after PR is merged:**

Has_image is  triggered when you changed the image_medium in form view.
POS load the new images.