### PR TITLE
[v10] fix apply pricelist when adding product to order.

### DIFF
--- a/pos_pricelist/static/src/js/models.js
+++ b/pos_pricelist/static/src/js/models.js
@@ -206,11 +206,13 @@ odoo.define("pos_pricelist.models", function (require) {
     models.Orderline.prototype.initialize = function (attr, options) {
         _Orderline_initialize.apply(this, arguments);
         if (options.product) {
-            options.price ||
-            this.product.get_price(
-                this.order.pricelist,
-                this.get_quantity()
-            )
+            this.set_unit_price(
+                options.price ||
+                this.product.get_price(
+                    this.order.pricelist,
+                    this.get_quantity()
+                )
+            );
         }
     };
     models.Orderline.prototype.init_from_JSON = function () {

--- a/pos_pricelist/static/src/js/models.js
+++ b/pos_pricelist/static/src/js/models.js
@@ -206,13 +206,8 @@ odoo.define("pos_pricelist.models", function (require) {
     models.Orderline.prototype.initialize = function (attr, options) {
         _Orderline_initialize.apply(this, arguments);
         if (options.product) {
-            this.set_unit_price(
-                options.product.price ||
-                this.product.get_price(
-                    this.order.pricelist,
-                    this.get_quantity()
-                )
-            );
+            var unit_price = this.order.pricelist ? this.product.get_price(this.order.pricelist,this.get_quantity()) : options.product.price;
+            this.set_unit_price(unit_price);
         }
     };
     models.Orderline.prototype.init_from_JSON = function () {

--- a/pos_pricelist/static/src/js/models.js
+++ b/pos_pricelist/static/src/js/models.js
@@ -206,8 +206,11 @@ odoo.define("pos_pricelist.models", function (require) {
     models.Orderline.prototype.initialize = function (attr, options) {
         _Orderline_initialize.apply(this, arguments);
         if (options.product) {
-            var unit_price = this.order.pricelist ? this.product.get_price(this.order.pricelist,this.get_quantity()) : options.product.price;
-            this.set_unit_price(unit_price);
+            options.price ||
+            this.product.get_price(
+                this.order.pricelist,
+                this.get_quantity()
+            )
         }
     };
     models.Orderline.prototype.init_from_JSON = function () {


### PR DESCRIPTION
I've faced the problem that when I first choose the pricelist in a new order, I see the prices of procuts impacted accordingly, but when I add the product to the order, they have the base price and not the reduced one.
So i checked the javascript and found that on order line initialisation you are setting base product price or pricelist price.
The modification I've made takes the pricelist price if a pricelist is set on order, otherwise it will take the default product price.
I don't really understand you code:
`this.set_unit_price(`
`    options.product.price ||`
`    this.product.get_price(`
`        this.order.pricelist,`
`        this.get_quantity()`
`    )`
`);`
in which case the order line would take the pricelist price in the code above? if price is not set on product?