### PR TITLE
[FIX] pos_order_return: return picking and invoices

### DIFF
--- a/pos_order_return/i18n/es.po
+++ b/pos_order_return/i18n/es.po
@@ -179,6 +179,12 @@ msgid "Returnable Quantity"
 msgstr "Cantidad retornable"
 
 #. module: pos_order_return
+#: code:addons/pos_order_return/models/pos_order.py:55
+#, python-format
+msgid "Return of %s"
+msgstr "Devolución de %s"
+
+#. module: pos_order_return
 #: model:ir.model.fields,field_description:pos_order_return.field_pos_order_line_returned_line_id
 #: model:ir.model.fields,field_description:pos_order_return.field_pos_order_returned_order_id
 msgid "Returned Order"

--- a/pos_order_return/tests/test_pos_order_return.py
+++ b/pos_order_return/tests/test_pos_order_return.py
@@ -78,6 +78,7 @@ class TestPOSOrderReturn(common.HttpCase):
         # Partner balance is 0
         self.assertEqual(sum(
             self.partner.mapped('invoice_ids.amount_total_signed')), 0)
+        self.assertEqual(self.pos_order.picking_id.state, 'done')
 
     def test_pos_order_partial_refund(self):
         partial_refund = self.env['pos.partial.return.wizard'].with_context({
@@ -100,3 +101,4 @@ class TestPOSOrderReturn(common.HttpCase):
         # Partner balance is 1350
         self.assertEqual(sum(
             self.partner.mapped('invoice_ids.amount_total_signed')), 1350)
+        self.assertEqual(self.pos_order.picking_id.state, 'done')


### PR DESCRIPTION
- Odoo already prepares a refund invoice in case negativa
- Return pickings weren't being auto validated as regular ones.

cc @Tecnativa