### PR TITLE
[FIX] pos_order_mgmt: reprint tickets with fp

### DIFF
--- a/pos_order_mgmt/__manifest__.py
+++ b/pos_order_mgmt/__manifest__.py
@@ -5,7 +5,7 @@
 {
     'name': 'POS Frontend Orders Management',
     'summary': 'Manage old POS Orders from the frontend',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'category': 'Point of Sale',
     'author': 'GRAP, '
               'Tecnativa, '

--- a/pos_order_mgmt/static/src/js/models.js
+++ b/pos_order_mgmt/static/src/js/models.js
@@ -12,7 +12,7 @@ odoo.define('pos_order_mgmt.models', function (require) {
         if (arguments.length && arguments[0] && arguments[0].uid) {
             var order = this.db.get_order(arguments[0].uid);
             if (order && order.data) {
-                var data = Object.assign({}, order.data);
+                var data = _.extend({}, order.data);
                 var partner = this.db.get_partner_by_id(data.partner_id);
                 if (partner && partner.id && partner.name) {
                     data.partner_id = [partner.id, partner.name];


### PR DESCRIPTION
When the PoS is using fiscal positions it can lead to errors when
computing the reprinted ticket value because the tax mapping function
computes them from the current order instead of from the one belonging
to the line.

So we set our loaded order temporarily as the selected one
just to bring it back to the current one after it's printed.

cc @Tecnativa