### PR TITLE
[8.0][FIX] pos_payment_terminal

### DIFF
--- a/pos_payment_terminal/static/src/js/pos_payment_terminal.js
+++ b/pos_payment_terminal/static/src/js/pos_payment_terminal.js
@@ -11,9 +11,10 @@ openerp.pos_payment_terminal = function(instance){
     module = instance.point_of_sale;
 
     module.ProxyDevice = module.ProxyDevice.extend({
-        payment_terminal_transaction_start: function(line, currency_iso){
+        payment_terminal_transaction_start: function(line, currency_iso, currency_decimals){
             var data = {'amount' : line.get_amount(),
                         'currency_iso' : currency_iso,
+                        'currency_decimals': currency_decimals,
                         'payment_mode' : line.cashregister.journal.payment_mode};
             this.message('payment_terminal_transaction_start', {'payment_info' : JSON.stringify(data)});
         },
@@ -25,7 +26,9 @@ openerp.pos_payment_terminal = function(instance){
             var self = this;
             if (line.cashregister.journal.payment_mode && this.pos.config.iface_payment_terminal){
                 el_node.querySelector('.payment-terminal-transaction-start')
-                    .addEventListener('click', function(){self.pos.proxy.payment_terminal_transaction_start(line, self.pos.currency.name)});
+                    .addEventListener('click', function(){
+                        self.pos.proxy.payment_terminal_transaction_start(line, self.pos.currency.name, self.pos.currency.decimals);
+                    });
                 }
             return el_node;
         },


### PR DESCRIPTION
pos_payment_terminal is supposed to work with [hw_telium_payment_terminal](https://github.com/OCA/pos/blob/8.0/hw_telium_payment_terminal/), but the telium controller [expects to be told](https://github.com/OCA/pos/blob/8.0/hw_telium_payment_terminal/controllers/main.py#L132) the number of decimals of the currency used for the transaction.

This pull requests make pos_payment_terminal communicate the numbers of decimals to the posbox proxy.

I suppose it should also be ported to branch 9.0?