### PR TITLE
[8.0][FIX] Avoid rules with min_quantity=0 in update_products_from_ui

### DIFF
--- a/pos_pricelist/static/src/js/models.js
+++ b/pos_pricelist/static/src/js/models.js
@@ -554,6 +554,9 @@ function pos_pricelist_models(instance, module) {
                 var quantities = [];
                 quantities.push(1);
                 for (var j = 0; j < rules.length; j++) {
+                    if (rules[j].min_quantity == 0.0 )
+                        continue;
+
                     if ($.inArray(rules[j].min_quantity, quantities) === -1) {
                         quantities.push(rules[j].min_quantity);
                     }


### PR DESCRIPTION
Because in pos it shows products with price in 0.0 when get price at function `get_base_price` of *models.js* in point_of_sale addon. 

```js
        get_base_price:    function(){
            var rounding = this.pos.currency.rounding;
            return round_pr(this.get_unit_price() * this.get_quantity() * (1 - this.get_discount()/100), rounding);
        },
```

When it calls to `simulate_price` it creates an **Orderline** with min_quantity and if it is 0.0, then `this.get_quantity()` equals to 0.0 and `get_base_price` returns 0.0

This change avoid to push **min_quantity of 0.0** to `quantities array`. So, simulate price for 1.0 unit qty instead.