### PR TITLE
[FIX][8.0] hw_telium_payment_terminal - python3 syntax to prepare migration

### DIFF
--- a/hw_telium_payment_terminal/controllers/main.py
+++ b/hw_telium_payment_terminal/controllers/main.py
@@ -255,7 +255,7 @@ class TeliumPaymentTerminalDriver(Thread):
                         if self.get_one_byte_answer('EOT'):
                             logger.info("Answer received from Terminal")
 
-        except Exception, e:
+        except Exception as e:
             logger.error('Exception in serial connection: %s' % str(e))
         finally:
             if self.serial:

--- a/hw_telium_payment_terminal/test-scripts/telium-test.py
+++ b/hw_telium_payment_terminal/test-scripts/telium-test.py
@@ -49,7 +49,7 @@ def initialize_msg(serial):
         if get_one_byte_answer(serial, 'ACK'):
             return True
         else:
-            print "Terminal : SAME PLAYER TRY AGAIN"
+            print("Terminal : SAME PLAYER TRY AGAIN")
             send_one_byte_signal(serial, 'EOT')
             # Wait 1 sec between each attempt
             time.sleep(1)
@@ -61,7 +61,7 @@ def send_one_byte_signal(serial, signal):
     assert signal in ascii_names, 'Wrong signal'
     char = ascii_names.index(signal)
     serial_write(serial, chr(char))
-    print 'Signal %s sent to terminal' % signal
+    print('Signal %s sent to terminal' % signal)
 
 
 def get_one_byte_answer(serial, expected_signal):
@@ -69,7 +69,7 @@ def get_one_byte_answer(serial, expected_signal):
     one_byte_read = serial.read(1)
     expected_char = ascii_names.index(expected_signal)
     if one_byte_read == chr(expected_char):
-        print "%s received from terminal" % expected_signal
+        print("%s received from terminal" % expected_signal)
         return True
     else:
         return False
@@ -81,14 +81,14 @@ def prepare_data_to_send():
     elif PAYMENT_MODE == 'card':
         payment_mode = '1'
     else:
-        print "The payment mode '%s' is not supported" % PAYMENT_MODE
+        print("The payment mode '%s' is not supported" % PAYMENT_MODE)
         return False
     cur_iso_letter = CURRENCY_ISO.upper()
     try:
         cur = pycountry.currencies.get(alpha_3=cur_iso_letter)
         cur_numeric = str(cur.numeric)
     except:
-        print "Currency %s is not recognized" % cur_iso_letter
+        print("Currency %s is not recognized" % cur_iso_letter)
         return False
     data = {
         'pos_number': str(1).zfill(2),
@@ -124,13 +124,13 @@ def send_message(serial, data):
         data['private'] +
         data['delay'] +
         data['auto'])
-    print 'Real message to send = %s' % real_msg
+    print('Real message to send = %s' % real_msg)
     assert len(real_msg) == 34, 'Wrong length for protocol E+'
     real_msg_with_etx = real_msg + chr(ascii_names.index('ETX'))
     lrc = generate_lrc(real_msg_with_etx)
     message = chr(ascii_names.index('STX')) + real_msg_with_etx + chr(lrc)
     serial_write(serial, message)
-    print 'Message sent to terminal'
+    print('Message sent to terminal')
 
 
 def compare_data_vs_answer(data, answer_data):
@@ -138,7 +138,7 @@ def compare_data_vs_answer(data, answer_data):
             'pos_number', 'amount_msg',
             'currency_numeric', 'private']:
         if data[field] != answer_data[field]:
-            print (
+            print(
                 "Field %s has value '%s' in data and value '%s' in answer"
                 % (field, data[field], answer_data[field]))
 
@@ -152,7 +152,7 @@ def parse_terminal_answer(real_msg, data):
         'currency_numeric': real_msg[12:15],
         'private': real_msg[15:26],
     }
-    print 'answer_data = %s' % answer_data
+    print('answer_data = %s' % answer_data)
     compare_data_vs_answer(data, answer_data)
     return answer_data
 
@@ -161,18 +161,19 @@ def get_answer_from_terminal(serial, data):
     ascii_names = curses.ascii.controlnames
     full_msg_size = 1+2+1+8+1+3+10+1+1
     msg = serial.read(size=full_msg_size)
-    print '%d bytes read from terminal' % full_msg_size
+    print('%d bytes read from terminal' % full_msg_size)
     assert len(msg) == full_msg_size, 'Answer has a wrong size'
     if msg[0] != chr(ascii_names.index('STX')):
-        print 'The first byte of the answer from terminal should be STX'
+        print('The first byte of the answer from terminal should be STX')
     if msg[-2] != chr(ascii_names.index('ETX')):
-        print 'The byte before final of the answer from terminal should be ETX'
+        print('The byte before final of the answer '
+              'from terminal should be ETX')
     lrc = msg[-1]
     computed_lrc = chr(generate_lrc(msg[1:-1]))
     if computed_lrc != lrc:
-        print 'The LRC of the answer from terminal is wrong'
+        print('The LRC of the answer from terminal is wrong')
     real_msg = msg[1:-2]
-    print 'Real answer received = %s' % real_msg
+    print('Real answer received = %s' % real_msg)
     return parse_terminal_answer(real_msg, data)
 
 
@@ -189,7 +190,7 @@ def transaction_start():
         # that we have to wait to up 3 seconds to get LRC
         serial = Serial(
             DEVICE, DEVICE_RATE, timeout=3)
-        print 'serial.is_open = %s' % serial.isOpen()
+        print('serial.is_open = %s' % serial.isOpen())
         if initialize_msg(serial):
             data = prepare_data_to_send()
             if not data:
@@ -198,19 +199,19 @@ def transaction_start():
             if get_one_byte_answer(serial, 'ACK'):
                 send_one_byte_signal(serial, 'EOT')
 
-                print "Now expecting answer from Terminal"
+                print("Now expecting answer from Terminal")
                 if get_one_byte_answer(serial, 'ENQ'):
                     send_one_byte_signal(serial, 'ACK')
                     get_answer_from_terminal(serial, data)
                     send_one_byte_signal(serial, 'ACK')
                     if get_one_byte_answer(serial, 'EOT'):
-                        print "Answer received from Terminal"
+                        print("Answer received from Terminal")
 
-    except Exception, e:
-        print 'Exception in serial connection: %s' % str(e)
+    except Exception as e:
+        print('Exception in serial connection: %s' % str(e))
     finally:
         if serial:
-            print 'Closing serial port for payment terminal'
+            print('Closing serial port for payment terminal')
             serial.close()
 
 


### PR DESCRIPTION
This PR is mostly harmless. It is about adopting python 3 syntax for `print` and `except` so the linter tools of my editor will not cry.

If it is ok with you, I would like to apply some tools like `black` in another pull request. What do you think about that?