### PR TITLE
[FIX] pos_order_mgmt: Xml receipt renders different values

### DIFF
--- a/pos_order_mgmt/static/src/js/widgets.js
+++ b/pos_order_mgmt/static/src/js/widgets.js
@@ -163,23 +163,15 @@ odoo.define('pos_order_mgmt.widgets', function (require) {
             // taxes based on fiscal position
             this.pos.current_order = this.pos.get_order()
             this.pos.set_order(order);
-            if (this.pos.config.iface_print_via_proxy) {
-                this.pos.proxy.print_receipt(QWeb.render(
-                    'XmlReceipt', {
-                        receipt: receipt,
-                        widget: this,
-                        pos: this.pos,
-                        order: order,
-                        orderlines: order.get_orderlines(),
-                        paymentlines: order.get_paymentlines(),
-                    }));
-                this.pos.set_order(this.pos.current_order);
-                this.pos.current_order = false;
-            } else {
-                this.pos.reloaded_order = order;
-                this.gui.show_screen('receipt');
-                this.pos.reloaded_order = false;
-            }
+            this.pos.reloaded_order = order;
+            var skip_screen_state = this.pos.config.iface_print_skip_screen;
+            // Disable temporarily skip screen if set
+            this.pos.config.iface_print_skip_screen = false;
+            this.gui.show_screen('receipt');
+            this.pos.reloaded_order = false;
+            // Set skip screen to whatever previous state
+            this.pos.config.iface_print_skip_screen = skip_screen_state;
+
         },
 
         action_return: function (order) {


### PR DESCRIPTION
- In some cases, the rendered ticket is not fine when we directly send
to XmlReceipt print.
- To get rid of this kind of issues, we allways go to the receipt screen
wich will allways give us the same results for both options (html and
escpos).

cc @Tecnativa TT19501