### PR TITLE
[FIX] pos_stock_picking_invoice_link: ensure test correctness

### DIFF
--- a/pos_stock_picking_invoice_link/tests/test_point_of_sale_stock_invoice_link.py
+++ b/pos_stock_picking_invoice_link/tests/test_point_of_sale_stock_invoice_link.py
@@ -22,8 +22,20 @@ class TestPointOfSaleStockPickingInvoiceLink(common.HttpCase):
             'standard_price': 1.0,
             'type': 'product',
         })
+        self.pricelist = self.env['product.pricelist'].create({
+            'name': 'Test pricelist',
+            'item_ids': [(0, 0, {
+                'applied_on': '3_global',
+                'compute_price': 'formula',
+                'base': 'list_price',
+            })]
+        })
         self.PosOrder = self.env['pos.order']
         self.pos_config = self.env.ref('point_of_sale.pos_config_main')
+        self.pos_config.write({
+            'available_pricelist_ids': [(6, 0, self.pricelist.ids)],
+            'pricelist_id': self.pricelist.id,
+        })
 
     def test_stock_picking_invoice_link(self):
         """The picking is created and the lines are related to their moves"""


### PR DESCRIPTION
When the currency of test environment is different from the one of de
demo data, the test will fail. We must ensure that we create a pricelist
with the current company defaults.

cc @Tecnativa TT18619