### PR TITLE
[8.0] [ADD] pos_round_payment: Allow to round payment to 5 cents

### DIFF
--- a/pos_round_payment/README.rst
+++ b/pos_round_payment/README.rst
@@ -1,0 +1,44 @@
+Point Of Sales Round Payment
+============================
+
+Allow to round payment method to 5 cents.
+You can choose to round only the cash payment or all the payment method. You
+need to enable the feature on the payment journal.
+Rounding only occurs for B2C (i.e. if partner does not have a VAT number).
+
+The pos order will be marked as paid with a difference between the total and
+paid amount. When reconciling the posted entries after the end of the pos
+session, the difference must be written on a write-off account.
+
+Installation
+============
+
+To install this module, you just need to select the module and insure yourself dependencies are available.
+
+Configuration
+=============
+
+No configuration to use this module.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Jacques-Etienne Baudoux <je@bcim.be> (BCIM sprl)
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/pos_round_payment/__init__.py
+++ b/pos_round_payment/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizards

--- a/pos_round_payment/__openerp__.py
+++ b/pos_round_payment/__openerp__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Jacques-Etienne Baudoux (BCIM sprl) <je@bcim.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    'name': "pos_round_payment",
+    'version': '1.0',
+    'category': 'Point Of Sale',
+    'author': "BCIM",
+    'website': "https://www.bcim.be",
+    'depends': [
+        'point_of_sale',
+        ],
+    'data': [
+        'views/account_journal.xml',
+        'reports/pos_receipt.xml',
+        ],
+    'installable': True,
+    'auto_install': False,
+    'license': 'AGPL-3',
+}

--- a/pos_round_payment/__openerp__.py
+++ b/pos_round_payment/__openerp__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
-    'name': "pos_round_payment",
+    'name': "POS Round Payment",
     'version': '1.0',
     'category': 'Point Of Sale',
     'author': "BCIM",

--- a/pos_round_payment/i18n/fr.po
+++ b/pos_round_payment/i18n/fr.po
@@ -1,0 +1,27 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#   * pos_round_payment
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-11-30 23:35+0000\n"
+"PO-Revision-Date: 2019-11-30 23:35+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: pos_round_payment
+#: field:account.journal,round_payment:0
+msgid "Round Payment to 5 cents"
+msgstr "Arrondir le paiement à 5 centimes"
+
+#. module: pos_round_payment
+#: view:website:point_of_sale.report_receipt
+msgid "Rounded"
+msgstr "Arrondi"
+

--- a/pos_round_payment/models/__init__.py
+++ b/pos_round_payment/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_journal
+from . import pos_order

--- a/pos_round_payment/models/account_journal.py
+++ b/pos_round_payment/models/account_journal.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Jacques-Etienne Baudoux (BCIM sprl) <je@bcim.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import models, fields
+
+
+class AccountJournal(models.Model):
+    _inherit = 'account.journal'
+
+    round_payment = fields.Boolean('Round Payment to 5 cents')

--- a/pos_round_payment/models/pos_order.py
+++ b/pos_round_payment/models/pos_order.py
@@ -2,7 +2,7 @@
 # Copyright 2019 Jacques-Etienne Baudoux (BCIM sprl) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from openerp import api, models, fields
+from openerp import api, models
 
 
 class PosOrder(models.Model):

--- a/pos_round_payment/models/pos_order.py
+++ b/pos_round_payment/models/pos_order.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Jacques-Etienne Baudoux (BCIM sprl) <je@bcim.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import api, models, fields
+
+
+class PosOrder(models.Model):
+    _inherit = "pos.order"
+
+    @api.multi
+    def test_paid(self):
+        """A Point of Sale is paid when the sum
+        @return: True
+        """
+        for order in self:
+            if order.lines and not order.amount_total:
+                return True
+            if not order.lines:
+                return False
+            if not order.statement_ids:
+                return False
+            amount = abs(order.amount_total-order.amount_paid)
+            if any(order.statement_ids.mapped('journal_id.round_payment')):
+                test = 0.021
+            else:
+                test = 0.009
+            if amount >= test:
+                return False
+        return True

--- a/pos_round_payment/reports/pos_receipt.xml
+++ b/pos_round_payment/reports/pos_receipt.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data>
+    <template id="report_pos_receipt" inherit_id="point_of_sale.report_receipt">
+        <xpath expr="//strong[@t-esc='formatLang(o.amount_total, currency_obj=res_company.currency_id)']" position="after">
+            <t t-if="abs(o.amount_total - o.amount_paid) >= 0.009">
+            <tr>
+                <td><strong>Rounded</strong></td>
+                <td class="text-right">
+                    <strong t-esc="formatLang(o.amount_paid, currency_obj=res_company.currency_id)"/>
+                </td>
+            </tr>
+            </t>
+        </xpath>
+    </template>
+</data>
+</openerp>

--- a/pos_round_payment/views/account_journal.xml
+++ b/pos_round_payment/views/account_journal.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data>
+    <record model="ir.ui.view" id="view_account_journal_pos_user_form">
+        <field name="name">POS Round Payment</field>
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="point_of_sale.view_account_journal_pos_user_form"/>
+        <field name="arch" type="xml">
+            <field name="journal_user" position="after">
+                <field name="round_payment"/>
+            </field>
+        </field>
+    </record>
+</data>
+</openerp>

--- a/pos_round_payment/wizards/__init__.py
+++ b/pos_round_payment/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import pos_payment

--- a/pos_round_payment/wizards/pos_payment.py
+++ b/pos_round_payment/wizards/pos_payment.py
@@ -34,7 +34,8 @@ class PosMakePayment(models.TransientModel):
         if amount != 0.0:
             data = self.read()[0]
             data['journal'] = data['journal_id'][0]
-            self.pool['pos.order'].add_payment(self._cr, self._uid, active_id, data, self._context)
+            self.pool['pos.order'].add_payment(
+                self._cr, self._uid, active_id, data, self._context)
 
         if order.test_paid():
             order.signal_workflow('paid')

--- a/pos_round_payment/wizards/pos_payment.py
+++ b/pos_round_payment/wizards/pos_payment.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Jacques-Etienne Baudoux (BCIM sprl) <je@bcim.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import api, models
+
+
+class PosMakePayment(models.TransientModel):
+    _inherit = 'pos.make.payment'
+
+    @api.onchange('journal_id')
+    def onchange_journal(self):
+        active_id = self.env.context.get('active_id', False)
+        order = self.env['pos.order'].browse(active_id)
+        if (not order.partner_id.commercial_partner_id.vat
+                and self.journal_id.round_payment):
+            self.amount = round(self.amount * 20) / 20
+        else:
+            self.amount = order.amount_total - order.amount_paid
+
+    @api.multi
+    def check(self):
+        """Check the order:
+        if the order is not paid: continue payment,
+        if the order is paid print ticket.
+        """
+        active_id = self.env.context.get('active_id', False)
+        order = self.env['pos.order'].browse(active_id)
+
+        amount = order.amount_total - order.amount_paid
+        if self.journal_id.round_payment:
+            amount = round(amount * 20) / 20
+
+        if amount != 0.0:
+            data = self.read()[0]
+            data['journal'] = data['journal_id'][0]
+            self.pool['pos.order'].add_payment(self._cr, self._uid, active_id, data, self._context)
+
+        if order.test_paid():
+            order.signal_workflow('paid')
+            return self.print_report()
+
+        return self.launch_payment()

--- a/setup/hw_customer_display/odoo_addons/hw_customer_display
+++ b/setup/hw_customer_display/odoo_addons/hw_customer_display
@@ -1,1 +1,0 @@
-../../../hw_customer_display

--- a/setup/hw_telium_payment_terminal/odoo_addons/hw_telium_payment_terminal
+++ b/setup/hw_telium_payment_terminal/odoo_addons/hw_telium_payment_terminal
@@ -1,1 +1,0 @@
-../../../hw_telium_payment_terminal

--- a/setup/pos_autoreconcile/odoo_addons/pos_autoreconcile
+++ b/setup/pos_autoreconcile/odoo_addons/pos_autoreconcile
@@ -1,1 +1,0 @@
-../../../pos_autoreconcile

--- a/setup/pos_customer_display/odoo_addons/pos_customer_display
+++ b/setup/pos_customer_display/odoo_addons/pos_customer_display
@@ -1,1 +1,0 @@
-../../../pos_customer_display

--- a/setup/pos_customer_required/odoo_addons/pos_customer_required
+++ b/setup/pos_customer_required/odoo_addons/pos_customer_required
@@ -1,1 +1,0 @@
-../../../pos_customer_required

--- a/setup/pos_default_empty_image/odoo_addons/pos_default_empty_image
+++ b/setup/pos_default_empty_image/odoo_addons/pos_default_empty_image
@@ -1,1 +1,0 @@
-../../../pos_default_empty_image

--- a/setup/pos_gift_ticket/odoo_addons/pos_gift_ticket
+++ b/setup/pos_gift_ticket/odoo_addons/pos_gift_ticket
@@ -1,1 +1,0 @@
-../../../pos_gift_ticket

--- a/setup/pos_invoice_journal/odoo_addons/pos_invoice_journal
+++ b/setup/pos_invoice_journal/odoo_addons/pos_invoice_journal
@@ -1,1 +1,0 @@
-../../../pos_invoice_journal

--- a/setup/pos_order_load/odoo_addons/pos_order_load
+++ b/setup/pos_order_load/odoo_addons/pos_order_load
@@ -1,1 +1,0 @@
-../../../pos_order_load

--- a/setup/pos_order_picking_link/odoo_addons/pos_order_picking_link
+++ b/setup/pos_order_picking_link/odoo_addons/pos_order_picking_link
@@ -1,1 +1,0 @@
-../../../pos_order_picking_link

--- a/setup/pos_order_pricelist_change/odoo_addons/pos_order_pricelist_change
+++ b/setup/pos_order_pricelist_change/odoo_addons/pos_order_pricelist_change
@@ -1,1 +1,0 @@
-../../../pos_order_pricelist_change

--- a/setup/pos_payment_terminal/odoo_addons/pos_payment_terminal
+++ b/setup/pos_payment_terminal/odoo_addons/pos_payment_terminal
@@ -1,1 +1,0 @@
-../../../pos_payment_terminal

--- a/setup/pos_pricelist/odoo_addons/pos_pricelist
+++ b/setup/pos_pricelist/odoo_addons/pos_pricelist
@@ -1,1 +1,0 @@
-../../../pos_pricelist

--- a/setup/pos_product_template/odoo_addons/pos_product_template
+++ b/setup/pos_product_template/odoo_addons/pos_product_template
@@ -1,1 +1,0 @@
-../../../pos_product_template

--- a/setup/pos_remove_pos_category/odoo_addons/pos_remove_pos_category
+++ b/setup/pos_remove_pos_category/odoo_addons/pos_remove_pos_category
@@ -1,1 +1,0 @@
-../../../pos_remove_pos_category


### PR DESCRIPTION
In Belgium, cash payment must now be rounded to 5 cents.
Allow to mark journal as rounded to 5 cents.
Order will be marked as paid with payment difference. The difference will be posted as a write-off when reconciling the pos orders entries. Write-off can be automatically posted with https://github.com/OCA/pos/pull/419

Tested with back-end only.