### PR TITLE
[12.0] FIX pos_partner_firstname allowing non admin users to get partner_names_order from POS frontend

### DIFF
--- a/pos_partner_firstname/models/res_partner.py
+++ b/pos_partner_firstname/models/res_partner.py
@@ -12,3 +12,8 @@ class ResPartner(models.Model):
         if 'is_company' in partner:
             partner['is_company'] = partner['is_company'] == 'true'
         return super(ResPartner, self).create_from_ui(partner)
+
+    @api.model
+    def get_names_order(self):
+        """Allow POS frontend to retrieve 'partner_names_order'"""
+        return self._get_names_order()

--- a/pos_partner_firstname/static/src/js/screens.js
+++ b/pos_partner_firstname/static/src/js/screens.js
@@ -11,9 +11,9 @@ odoo.define('pos_partner_firstname.screens', function (require) {
             var self = this;
             this._super(parent, options);
             this._rpc({
-                model: 'ir.config_parameter',
-                method: 'get_param',
-                args: ['partner_names_order'],
+                model: 'res.partner',
+                method: 'get_names_order',
+                args: [],
             }).then(function(partner_names_order) {
                 if (partner_names_order != false) {
                     self.partner_names_order = partner_names_order;


### PR DESCRIPTION

Otherwise they would get access error on ir.config_parameter

Steps:

 - Create a user POS manager without administration rights
 - Using that user, open POS frontend