### PR TITLE
[FIX] demo data. Cash move reason should not be purchasable / saleable

### DIFF
--- a/pos_cash_move_reason/demo/product_template.xml
+++ b/pos_cash_move_reason/demo/product_template.xml
@@ -8,12 +8,16 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
     <record id="income_reason" model="product.template">
         <field name="name">Miscellaneous income</field>
+        <field name="sale_ok" eval="False"/>
+        <field name="purchase_ok" eval="False"/>
         <field name="income_pdt" eval="True" />
         <field name="property_account_income" ref="account.o_income"/>
     </record>
 
     <record id="expense_reason" model="product.template">
         <field name="name">Miscellaneous expense</field>
+        <field name="sale_ok" eval="False"/>
+        <field name="purchase_ok" eval="False"/>
         <field name="expense_pdt" eval="True" />
         <field name="property_account_expense" ref="account.a_expense"/>
     </record>


### PR DESCRIPTION
fix demo data to make it consistent. move reason should not be purchasable / saleable.
In 12.0, it is not anymore cash move are not used with product.