### PR TITLE
[IMP] Set lot/serial number when returning orders

### DIFF
--- a/pos_order_mgmt/models/pos_order.py
+++ b/pos_order_mgmt/models/pos_order.py
@@ -136,6 +136,7 @@ class PosOrder(models.Model):
             'qty': order_line.qty,
             'price_unit': order_line.price_unit,
             'discount': order_line.discount,
+            'pack_lot_names': order_line.pack_lot_ids.mapped('lot_name'),
         }
 
     @api.multi

--- a/pos_order_mgmt/static/src/js/widgets.js
+++ b/pos_order_mgmt/static/src/js/widgets.js
@@ -12,7 +12,7 @@ odoo.define('pos_order_mgmt.widgets', function (require) {
     var screens = require('point_of_sale.screens');
     var gui = require('point_of_sale.gui');
     var chrome = require('point_of_sale.chrome');
-    var pos = require('point_of_sale.models');
+    var models = require('point_of_sale.models');
 
     var QWeb = core.qweb;
     var ScreenWidget = screens.ScreenWidget;
@@ -210,12 +210,24 @@ odoo.define('pos_order_mgmt.widgets', function (require) {
             order.trigger('change');
             this.pos.get('orders').add(order);
             this.pos.set('selectedOrder', order);
+            order.get_orderlines().forEach(function (orderline) {
+                if (orderline.pack_lot_lines)
+                {
+                    _.each(orderline.return_pack_lot_names, function(lot_name) {
+                        orderline.pack_lot_lines.add(new models.Packlotline(
+                            {'lot_name': lot_name}, {'order_line': orderline}
+                        ));
+                    })
+                    order.save_to_db();
+                    orderline.trigger('change', orderline);
+                }
+            });
             return order;
         },
 
         _prepare_order_from_order_data: function (order_data, action) {
             var self = this;
-            var order = new pos.Order({}, {
+            var order = new models.Order({}, {
                 pos: this.pos,
             });
 
@@ -324,12 +336,14 @@ odoo.define('pos_order_mgmt.widgets', function (require) {
                 // Invert line quantities
                 qty *= -1;
             }
-
             return {
                 price: line.price_unit,
                 quantity: qty,
                 discount: line.discount,
                 merge: false,
+                extras: {
+                    return_pack_lot_names: line.pack_lot_names,
+                },
             }
 
         },

--- a/pos_order_mgmt/static/src/js/widgets.js
+++ b/pos_order_mgmt/static/src/js/widgets.js
@@ -210,18 +210,6 @@ odoo.define('pos_order_mgmt.widgets', function (require) {
             order.trigger('change');
             this.pos.get('orders').add(order);
             this.pos.set('selectedOrder', order);
-            order.get_orderlines().forEach(function (orderline) {
-                if (orderline.pack_lot_lines)
-                {
-                    _.each(orderline.return_pack_lot_names, function(lot_name) {
-                        orderline.pack_lot_lines.add(new models.Packlotline(
-                            {'lot_name': lot_name}, {'order_line': orderline}
-                        ));
-                    })
-                    order.save_to_db();
-                    orderline.trigger('change', orderline);
-                }
-            });
             return order;
         },
 
@@ -324,6 +312,18 @@ odoo.define('pos_order_mgmt.widgets', function (require) {
                     order.add_product(product,
                         self._prepare_product_options_from_orderline_data(
                             order, line, action));
+                    // Restore lot information.
+                    if (['return'].indexOf(action) !== -1) {
+                        var orderline = order.get_selected_orderline()
+                        if (orderline.pack_lot_lines) {
+                            _.each(orderline.return_pack_lot_names, function(lot_name) {
+                                orderline.pack_lot_lines.add(new models.Packlotline(
+                                    {'lot_name': lot_name}, {'order_line': orderline}
+                                ));
+                            })
+                            orderline.trigger('change', orderline);
+                        }
+                    }
                 }
             });
         },


### PR DESCRIPTION
When returning an order, it'll copy the lot/serial number of the original order lines and set it by default on the refund order