### PR TITLE
[FIX] pos_order_return: bad image paths in readme segments

### DIFF
--- a/pos_order_return/readme/CONFIGURE.rst
+++ b/pos_order_return/readme/CONFIGURE.rst
@@ -4,8 +4,4 @@ products like returnable products, etc.
 
 In that case, a checkbox is possible on Product Form View to allow such case
 
-.. image:: /pos_order_return/static/description/product_returnable_bottle.png
-
-.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
-   :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/184/10.0
+.. image:: ../static/description/product_returnable_bottle.png

--- a/pos_order_return/readme/USAGE.rst
+++ b/pos_order_return/readme/USAGE.rst
@@ -2,7 +2,7 @@ Select an PoS Order an choose either *Return Products* (full return of the
 order) or *Partial Return*. In this case, a wizard allows to select just some
 products and quantities to return:
 
-.. image:: /pos_order_return/static/description/partial_return_wizard.png
+.. image:: ../static/description/partial_return_wizard.png
 
 Register the refund payment to finish the return. If the original order was
 invoiced, a refund invoice will be made.
@@ -11,13 +11,13 @@ invoiced, a refund invoice will be made.
 
 * User can not return more products than the initial quantity:
 
-.. image:: /pos_order_return/static/description/returned_qty_over_initial.png
+.. image:: ../static/description/returned_qty_over_initial.png
 
 * If a line has been partially refund, only a reduced quantity can be returned:
 
-.. image:: /pos_order_return/static/description/sum_returned_qty_over_initial.png
+.. image:: ../static/description/sum_returned_qty_over_initial.png
 
 * It is not possible to set a negative quantity if the initial Pos Order is
   not indicated:
 
-.. image:: /pos_order_return/static/description/initial_pos_order_required.png
+.. image:: ../static/description/initial_pos_order_required.png


### PR DESCRIPTION
Trivial patch 

- fix bad URL images in the main readme. see current broken readme : 
https://github.com/OCA/pos/blob/12.0/pos_order_return/README.rst

- remove useless link to runbot. (added automaticaly by the ocabot).

Thanks for your quick review.