### PR TITLE
[FIX] pos_order_return: prevent error when trying to refund a pos order without pickings

### DIFF
--- a/pos_order_return/models/pos_order.py
+++ b/pos_order_return/models/pos_order.py
@@ -125,9 +125,11 @@ class PosOrder(models.Model):
     def create_picking(self):
         """Odoo bases return picking if the quantities are negative, but it's
         not linked to the original one"""
-        res = super(PosOrder, self.filtered(lambda x: not x.returned_order_id)
-                    ).create_picking()
-        for order in self.filtered('returned_order_id'):
+        orders = self.filtered(
+            lambda x: not x.returned_order_id
+            or not x.returned_order_id.picking_id)
+        res = super(PosOrder, orders).create_picking()
+        for order in self - orders:
             wizard = order._create_picking_return()
             res = wizard.create_returns()
             order.write({'picking_id': res['res_id']})


### PR DESCRIPTION
A ``pos.order`` doesn't have always a picking.
A typical use case is if you sale a product type = service.
In that case, the module ``pos_order_return`` will raise an error, when trying to mark as paid, a refunded order. (see below)

This trivial patch prevent such errors.

@chienandalu : could you take a look ? 

Thanks !

```
File "ODOO_12_CE/src/odoo/addons/point_of_sale/wizard/pos_payment.py", line 62, in check
    order.action_pos_order_paid()
  File "ODOO_12_CE/src/pos/pos_order_return/models/pos_order.py", line 99, in action_pos_order_paid
    res = super(PosOrder, self).action_pos_order_paid()
  File "ODOO_12_CE/src/odoo/addons/point_of_sale/models/pos_order.py", line 688, in action_pos_order_paid
    return self.create_picking()
  File "ODOO_12_CE/src/pos/pos_order_return/models/pos_order.py", line 134, in create_picking
    res = wizard.create_returns()
  File "ODOO_12_CE/src/odoo/addons/stock/wizard/stock_picking_return.py", line 153, in create_returns
    new_picking_id, pick_type_id = wizard._create_returns()
  File "ODOO_12_CE/src/odoo/addons/stock_account/models/stock.py", line 740, in _create_returns
    new_picking_id, pick_type_id = super(StockReturnPicking, self)._create_returns()
  File "ODOO_12_CE/src/odoo/addons/stock/wizard/stock_picking_return.py", line 118, in _create_returns
    'location_dest_id': self.location_id.id})
  File "ODOO_12_CE/src/odoo/odoo/models.py", line 4313, in copy
    self.ensure_one()
  File "ODOO_12_CE/src/odoo/odoo/models.py", line 4744, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: stock.picking()
```