### PR TITLE
[FIX] pos_pricelist: external_dependencies_override

### DIFF
--- a/setup/pos_pricelist/setup.py
+++ b/setup/pos_pricelist/setup.py
@@ -2,5 +2,11 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['setuptools-odoo'],
-    odoo_addon=True,
+    odoo_addon={
+        "external_dependencies_override": {
+            "python": {
+                "oca.decorators": "oca-decorators",
+            },
+        },
+    },
 )


### PR DESCRIPTION
This is necessary to help some legacy setuptools code that does
not do the name normalization correctly.