### PR TITLE
[10.0][FIX] - handle the case where product is a dict

### DIFF
--- a/pos_pricelist/static/src/js/models.js
+++ b/pos_pricelist/static/src/js/models.js
@@ -206,12 +206,13 @@ odoo.define("pos_pricelist.models", function (require) {
     models.Orderline.prototype.initialize = function (attr, options) {
         _Orderline_initialize.apply(this, arguments);
         if (options.product) {
+            var product = new exports.Product(this.product);
             this.set_unit_price(
-                options.product.price ||
-                this.product.get_price(
+                product.get_price(
                     this.order.pricelist,
                     this.get_quantity()
-                )
+                ) ||
+                options.product.price
             );
         }
     };
@@ -225,7 +226,8 @@ odoo.define("pos_pricelist.models", function (require) {
         delete this.keep_price;
         // just like in sale.order changing the quantity will recompute the unit price
         if (!keep_price) {
-            this.set_unit_price(this.product.get_price(
+            var product = new exports.Product(this.product);
+            this.set_unit_price(product.get_price(
                 this.order.pricelist,
                 this.get_quantity()
             ));
@@ -260,8 +262,9 @@ odoo.define("pos_pricelist.models", function (require) {
         var self = this;
         this.pricelist = pricelist;
         _.each(this.get_orderlines(), function (line) {
+            var product = new exports.Product(line.product);
             line.set_unit_price(
-                line.product.get_price(self.pricelist, line.get_quantity())
+                product.get_price(self.pricelist, line.get_quantity())
             );
             self.fix_tax_included_price(line);
         });

--- a/pos_pricelist/static/src/js/screens.js
+++ b/pos_pricelist/static/src/js/screens.js
@@ -8,6 +8,7 @@ odoo.define("pos_pricelist.screens", function (require) {
     var screens = require("point_of_sale.screens");
     var _t = core._t;
     var exports = {};
+    var models = require("pos_pricelist.models");
 
     screens.ScaleScreenWidget.include({
         _get_active_pricelist: function() {
@@ -56,6 +57,7 @@ odoo.define("pos_pricelist.screens", function (require) {
 
     screens.ProductListWidget.include({
         init: function () {
+            this.models = models;
             this._super.apply(this, arguments);
             this.pos.get('orders').bind(
                 'add remove change',
@@ -83,6 +85,10 @@ odoo.define("pos_pricelist.screens", function (require) {
                 current_pricelist = current_order.pricelist;
             }
             return current_pricelist;
+        },
+        get_price: function(product, pricelist, quantity) {
+            var product = new this.models.Product(product);
+            return product.get_price(pricelist, quantity);
         },
     });
 

--- a/pos_pricelist/static/src/xml/pos.xml
+++ b/pos_pricelist/static/src/xml/pos.xml
@@ -41,11 +41,11 @@
 
     <t t-extend="Product">
         <t t-jquery=".price-tag:eq(0)" t-operation="inner">
-            <t t-esc="widget.format_currency(product.get_price(widget._get_active_pricelist(), 1),'Product Price')"/>
+            <t t-esc="widget.format_currency(widget.get_price(product, widget._get_active_pricelist(), 1),'Product Price')"/>
         </t>
 
-        <t t-jquery=".price-tag:eq(0)" t-operation="inner">
-            <t t-esc="widget.format_currency(product.get_price(widget._get_active_pricelist(), 1),'Product Price')+'/'+widget.pos.units_by_id[product.uom_id[0]].name"/>
+        <t t-jquery=".price-tag:eq(1)" t-operation="inner">
+            <t t-esc="widget.format_currency(widget.get_price(product, widget._get_active_pricelist(), 1),'Product Price')+'/'+widget.pos.units_by_id[product.uom_id[0]].name"/>
         </t>
     </t>
 </templates>


### PR DESCRIPTION
when `pos_cache` is installed, the product is read from the cache and became a `dict` instance instead of `OdooClass` object instance.

This PR, assures that `get_price` is always processed with an `OdooClass` object.

fixes: #274