### PR TITLE
12.0 fix pos order return

### DIFF
--- a/pos_order_return/models/pos_order.py
+++ b/pos_order_return/models/pos_order.py
@@ -93,6 +93,8 @@ class PosOrder(models.Model):
                     'returned_line_id': wizard_line.pos_order_line_id.id,
                     'qty': qty,
                 })
+                copy_line._onchange_amount_line_all()
+        new_order._onchange_amount_all()
         return res
 
     def action_pos_order_paid(self):

--- a/pos_order_return/models/pos_order.py
+++ b/pos_order_return/models/pos_order.py
@@ -72,12 +72,13 @@ class PosOrder(models.Model):
         for line in self.lines:
             qty = - line.max_returnable_qty([])
             if qty != 0:
-                copy_line = line.copy()
-                copy_line.write({
-                    'order_id': new_order.id,
-                    'returned_line_id': line.id,
-                    'qty': qty,
-                })
+                line.copy(
+                    {
+                        'order_id': new_order.id,
+                        'returned_line_id': line.id,
+                        'qty': qty,
+                    }
+                )
         return res
 
     def partial_refund(self, partial_return_wizard):
@@ -87,12 +88,13 @@ class PosOrder(models.Model):
         for wizard_line in partial_return_wizard.line_ids:
             qty = -wizard_line.qty
             if qty != 0:
-                copy_line = wizard_line.pos_order_line_id.copy()
-                copy_line.write({
-                    'order_id': new_order.id,
-                    'returned_line_id': wizard_line.pos_order_line_id.id,
-                    'qty': qty,
-                })
+                copy_line = wizard_line.pos_order_line_id.copy(
+                    {
+                        'order_id': new_order.id,
+                        'returned_line_id': wizard_line.pos_order_line_id.id,
+                        'qty': qty,
+                    }
+                )
                 copy_line._onchange_amount_line_all()
         new_order._onchange_amount_all()
         return res

--- a/pos_order_return/readme/CONTRIBUTORS.rst
+++ b/pos_order_return/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Sylvain LE GAL <https://twitter.com/legalsylvain>
 * David Vidal <david.vidal@tecnativa.com>
 * Kiril Vangelovski <kiril@lambda-is.com>
+* Druidoo <https://www.druidoo.io>


### PR DESCRIPTION
Issue 1:Pos order partial return gives wrong total
When create a partial pos order return amount total on return order is always copy from the original order

![pos_order_wrong_total](https://user-images.githubusercontent.com/7599757/83640847-566a3800-a5ca-11ea-88fa-641a5d163b23.png)

Issue 2: pos order return module is not working with `l10n_fr_pos_cert`

If `l10n_fr_pos_cert`  is installed user can not return pos order if order is Invoiced or Posted AND the company's country code falls in any of ['FR', 'MF', 'MQ', 'NC', 'PF', 'RE', 'GF', 'GP', 'TF'].
![pos_order_return](https://user-images.githubusercontent.com/7599757/83641241-e7411380-a5ca-11ea-91e6-0f28661a2d59.png)

