### PR TITLE
[FIX] typo in pos_customer_display

### DIFF
--- a/pos_customer_display/static/src/js/gui.js
+++ b/pos_customer_display/static/src/js/gui.js
@@ -14,7 +14,7 @@ odoo.define('pos_customer_display.gui', function (require) {
 
         close: function(){
             this.pos.proxy.send_text_customer_display(
-                this.pos.proxy.prepare_message_closed()
+                this.pos.proxy.prepare_message_close()
             );
             return this._super();
         },


### PR DESCRIPTION
trivial PR. the function ``prepare_message_closed`` doens't exist. 

ref : https://github.com/OCA/pos/blob/12.0/pos_customer_display/static/src/js/devices.js#L75

