### PR TITLE
[FIX] pos_order_mgmt test

### DIFF
--- a/pos_order_mgmt/tests/test_module.py
+++ b/pos_order_mgmt/tests/test_module.py
@@ -34,8 +34,7 @@ class TestModule(TransactionCase):
         })
 
         # Create a new pos config and open it
-        self.pos_config = self.env.ref('point_of_sale.pos_config_main').copy()
-        self.pos_config.write({
+        self.pos_config = self.env.ref('point_of_sale.pos_config_main').copy({
             'available_pricelist_ids': [(6, 0, self.pricelist.ids)],
             'pricelist_id': self.pricelist.id,
         })


### PR DESCRIPTION
If we `copy()` the config the currency error raises before prevent it.
Doing a `copy()` is meaningless anyway.

Sorry about the noise. Now tested for sure before PR :sweat_smile: 


cc @Tecnativa TT25280