### PR TITLE
[FIX][12.0] pos_cash_move_reason : date of statement line depends now on the context timezone

### DIFF
--- a/pos_cash_move_reason/wizard/wizard_pos_move_reason.py
+++ b/pos_cash_move_reason/wizard/wizard_pos_move_reason.py
@@ -90,7 +90,7 @@ class WizardPosMoveReason(models.TransientModel):
             account = self.move_reason_id.expense_account_id
             amount = - self.amount
         return {
-            'date': fields.Datetime.now(),
+            'date': fields.Date.context_today(self),
             'statement_id': self.statement_id.id,
             'journal_id': self.journal_id.id,
             'amount': amount,


### PR DESCRIPTION
Closes #507

Trivial patch. for the time being, the bank statement line generated by this module has a bad date. (doesn't take into account timezone). 
Applying same code as per odoo pos order payment. ref : https://github.com/odoo/odoo/blob/12.0/addons/point_of_sale/models/pos_order.py#L948

CC : @emavarela, @ecogit, @chienandalu

thanks.