### PR TITLE
[12.0] [IMP] pos_picking_load: returning widgets so they can be inherited

### DIFF
--- a/pos_picking_load/static/src/js/widget.js
+++ b/pos_picking_load/static/src/js/widget.js
@@ -317,4 +317,9 @@ odoo.define('pos_picking_load.widget', function (require) {
         },
     });
 
+    return {
+        LoadPickingScreenWidget: LoadPickingScreenWidget,
+        LoadPickingButtonWidget: LoadPickingButtonWidget,
+    }
+
 });


### PR DESCRIPTION
All new widgets should be returned.
Because right now there isn't really a way to inherit the widget and add some functionality to it.