### PR TITLE
[12.0][FIX] pos order to sale order : dependencies and compatibility with pos_restaurant

### DIFF
--- a/pos_order_to_sale_order/__manifest__.py
+++ b/pos_order_to_sale_order/__manifest__.py
@@ -8,7 +8,7 @@
     "author": "GRAP,Odoo Community Association (OCA)",
     "category": "Point Of Sale",
     "license": "AGPL-3",
-    "depends": ["point_of_sale"],
+    "depends": ["point_of_sale", "sale"],
     "maintainers": ["legalsylvain"],
     "development_status": "Production/Stable",
     "website": "https://github.com/OCA/pos",

--- a/pos_order_to_sale_order/static/src/js/screens.js
+++ b/pos_order_to_sale_order/static/src/js/screens.js
@@ -35,7 +35,11 @@ odoo.define('pos_order_to_sale_order.screens', function (require) {
         },
 
         is_visible: function () {
-            return this.pos.get_order().orderlines.length > 0;
+            if (this.pos.get_order()){
+                return this.pos.get_order().orderlines.length > 0;
+            } else {
+                return false;
+            }
         },
 
     });


### PR DESCRIPTION
Two trivial fixes. 

- In odoo 12, ``point_of_sale`` doesn't depends on ``sale`` anymore. So for the time being, the module is failing, if ``sale`` module is not installed. (hidden bug, because UNITTEST is not enabled on Travis).
- ``pos_order_to_sale_order`` will fail when lauching the PoS, if ``pos_restaurant`` is installed because with ``pos_restaurant`` installed, the function ``get_order()`` can now return null value.


CC : @SandieFavre, @quentinDupont #GRAPOCA