### PR TITLE
[FIX] pos_customer_display: compatibility with pos_restaurant

### DIFF
--- a/pos_customer_display/static/src/js/screens.js
+++ b/pos_customer_display/static/src/js/screens.js
@@ -12,7 +12,10 @@ odoo.define('pos_customer_display.screens', function (require) {
     screens.PaymentScreenWidget.include({
 
         render_paymentlines: function() {
-            if (this.pos.get_order().get_total_with_tax() === 0) {
+            if (
+                !this.pos.get_order() ||
+                (this.pos.get_order() && this.pos.get_order().get_total_with_tax() === 0)
+            ) {
                 // Render payment is called each time a new order is created
                 // (and so when lauching the PoS)
                 // in that case, we display the welcome message


### PR DESCRIPTION
similar to #539 

don't crash if ``get_order()`` is null, that occures if ``pos_restaurant`` is enabled.

CC : @SandieFavre, @quentinDupont #GRAPOCA