### PR TITLE
[IMP] pos_payment_terminal : improve display of the loading button

### DIFF
--- a/pos_payment_terminal/static/src/js/screens.js
+++ b/pos_payment_terminal/static/src/js/screens.js
@@ -32,9 +32,9 @@ odoo.define('pos_payment_terminal.screens', function (require) {
             if (!order) {
                 return;
             } else if (order.in_transaction) {
-                self.$('.next').html('<img src="/web/static/src/img/spin.png" style="animation: fa-spin 1s infinite steps(12);width: 20px;height: auto;vertical-align: middle;">');
+                this.$('.in_transaction').removeClass('oe_hidden');
             } else {
-                self.$('.next').html('Validate <i class="fa fa-angle-double-right"></i>');
+                this.$('.in_transaction').addClass('oe_hidden');
             }
         }
     });

--- a/pos_payment_terminal/static/src/xml/pos_payment_terminal.xml
+++ b/pos_payment_terminal/static/src/xml/pos_payment_terminal.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
+
+    <t t-extend="PaymentScreenWidget" >
+        <t t-jquery=".next" t-operation="after">
+            <span class="button in_transaction" style="right: 0px; margin-right: 150px;">
+                <img src="/web/static/src/img/spin.png"
+                    style="animation: fa-spin 1s infinite steps(12);width: 20px;height: auto;vertical-align: middle; "/>
+            </span>
+        </t>
+    </t>
+
     <t t-extend="PaymentScreen-Paymentlines" >
         <t t-jquery=".col-name" t-operation="append">
             <t t-if="line.cashregister.journal.pos_terminal_payment_mode and widget.pos.config.iface_payment_terminal">
@@ -7,4 +17,5 @@
             </t>
         </t>
     </t>
+
 </templates>


### PR DESCRIPTION
improve display of the loading button in the pos_payment_terminal module.

context : 
when communicating with the terminal, for the time being, the validate button changes.
so, if the communication fails, the button never goes back to the original display. So adding a new button.

(also improve code, before inserting html by javascript is not a good practice). 

## Before

![image](https://user-images.githubusercontent.com/3407482/95239112-c9025300-080a-11eb-9446-9cab53dcd36c.png)


## After

![image](https://user-images.githubusercontent.com/3407482/95238867-6c069d00-080a-11eb-832c-389582d82da5.png)


CC : @alexis-via, @ivantodorovich, @SandieFavre, @quentinDupont #GRAPOCA

Thanks.