### PR TITLE
[10.0] pos_payment_terminal: display an error to the cashier in case of technical failure

### DIFF
--- a/pos_payment_terminal/i18n/fr.po
+++ b/pos_payment_terminal/i18n/fr.po
@@ -1,23 +1,19 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * pos_payment_terminal
+#	* pos_payment_terminal
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2017
-# leemannd <denis.leemann@camptocamp.com>, 2017
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-01 02:01+0000\n"
-"PO-Revision-Date: 2018-03-01 02:01+0000\n"
-"Last-Translator: leemannd <denis.leemann@camptocamp.com>, 2017\n"
-"Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
-"Language: fr\n"
+"POT-Creation-Date: 2020-10-19 14:57+0000\n"
+"PO-Revision-Date: 2020-10-19 14:57+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: \n"
 
 #. module: pos_payment_terminal
 #: selection:account.journal,payment_mode:0
@@ -30,6 +26,13 @@ msgid "Check"
 msgstr "Chèque"
 
 #. module: pos_payment_terminal
+#. openerp-web
+#: code:addons/pos_payment_terminal/static/src/js/pos_payment_terminal.js:101
+#, python-format
+msgid "Failed to send the amount to pay to the payment terminal. Press the red button on the payment terminal and try again."
+msgstr "Échec de l'envoi du montant à payer au lecteur CB. Appuyez sur le bouton rouge du lecteur CB et essayez à nouveau."
+
+#. module: pos_payment_terminal
 #: model:ir.model,name:pos_payment_terminal.model_account_journal
 msgid "Journal"
 msgstr "Journal"
@@ -40,9 +43,16 @@ msgid "Payment Mode"
 msgstr "Moyen de paiement"
 
 #. module: pos_payment_terminal
+#. openerp-web
+#: code:addons/pos_payment_terminal/static/src/js/pos_payment_terminal.js:100
+#, python-format
+msgid "Payment Terminal Error"
+msgstr "Erreur - Lecteur CB"
+
+#. module: pos_payment_terminal
 #: model:ir.model,name:pos_payment_terminal.model_pos_order
 msgid "Point of Sale Orders"
-msgstr ""
+msgstr "Commandes du point de vente"
 
 #. module: pos_payment_terminal
 #: model:ir.model.fields,help:pos_payment_terminal.field_account_journal_payment_mode
@@ -60,3 +70,4 @@ msgstr "Démarrer la transaction"
 #: model:ir.model,name:pos_payment_terminal.model_pos_config
 msgid "pos.config"
 msgstr "pos.config"
+


### PR DESCRIPTION
Display an error to the cashier in case of technical failure when sending the amount to the payment terminal

Update FR translation

If you use pywebdriver, you should update it to https://github.com/akretion/pywebdriver/pull/53 to benefit from this improvement. And you must also update to pypostelium 0.0.4, cf https://github.com/akretion/pypostelium