### PR TITLE
 [FIX] pos_customer_display : do not raise error if text === False

### DIFF
--- a/pos_customer_display/static/src/js/devices.js
+++ b/pos_customer_display/static/src/js/devices.js
@@ -41,6 +41,12 @@ odoo.define('pos_customer_display.devices', function (require) {
         },
 
         _prepare_line: function(left_part, right_part){
+            if (left_part === false){
+                left_part = "";
+            }
+            if (right_part === false){
+                right_part = "";
+            }
             var line_length = this.pos.config.customer_display_line_length;
             var max_left_length = line_length;
             if (right_part.length !== 0) {


### PR DESCRIPTION
trivial patch. if text to send to the customer display is null (that occures if pos.config is not set) an error is raised.

CC : @alexis-via, @quentinDupont #GRAPOCA