### PR TITLE
 [IMP] pos_payment_terminal : improve the display of the button start transaction

### DIFF
--- a/pos_payment_terminal/i18n/fr.po
+++ b/pos_payment_terminal/i18n/fr.po
@@ -6,11 +6,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-18 10:52+0000\n"
-"PO-Revision-Date: 2020-01-18 10:52+0000\n"
+"POT-Creation-Date: 2020-11-12 15:11+0000\n"
+"PO-Revision-Date: 2020-11-12 15:11+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -34,7 +33,7 @@ msgstr "Chèque"
 #. module: pos_payment_terminal
 #: model:ir.model,name:pos_payment_terminal.model_account_journal
 msgid "Journal"
-msgstr "Journal"
+msgstr ""
 
 #. module: pos_payment_terminal
 #: model:ir.model.fields,field_description:pos_payment_terminal.field_pos_config__iface_payment_terminal
@@ -60,7 +59,7 @@ msgstr "Sélectionner le mode de paiement envoyé au terminal de paiement"
 
 #. module: pos_payment_terminal
 #. openerp-web
-#: code:addons/pos_payment_terminal/static/src/xml/pos_payment_terminal.xml:16
+#: code:addons/pos_payment_terminal/static/src/xml/pos_payment_terminal.xml:17
 #, python-format
 msgid "Start transaction"
 msgstr "Démarrer la transaction"
@@ -68,6 +67,5 @@ msgstr "Démarrer la transaction"
 #. module: pos_payment_terminal
 #: model:ir.model.fields,field_description:pos_payment_terminal.field_account_bank_statement_import_journal_creation__pos_terminal_payment_mode
 #: model:ir.model.fields,field_description:pos_payment_terminal.field_account_journal__pos_terminal_payment_mode
-#, fuzzy
 msgid "Terminal Payment Mode"
 msgstr "Moyen de paiement"

--- a/pos_payment_terminal/i18n/pos_payment_terminal.pot
+++ b/pos_payment_terminal/i18n/pos_payment_terminal.pot
@@ -1,11 +1,13 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#	* pos_payment_terminal
+#   * pos_payment_terminal
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-11-12 15:12+0000\n"
+"PO-Revision-Date: 2020-11-12 15:12+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -57,7 +59,7 @@ msgstr ""
 
 #. module: pos_payment_terminal
 #. openerp-web
-#: code:addons/pos_payment_terminal/static/src/xml/pos_payment_terminal.xml:16
+#: code:addons/pos_payment_terminal/static/src/xml/pos_payment_terminal.xml:17
 #, python-format
 msgid "Start transaction"
 msgstr ""

--- a/pos_payment_terminal/static/src/css/pos_payment_terminal.css
+++ b/pos_payment_terminal/static/src/css/pos_payment_terminal.css
@@ -1,12 +1,7 @@
-.payment-terminal-transaction-start button {
-    width: 150px;
-    height: 60px;
-    font-size: 18px;
-    cursor: pointer;
-    text-align:center;
-    box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    left: 105%;
-    bottom: 10px;
-    position: absolute;
+button.payment-terminal-transaction-start {
+    /*Same css values as ".screen .top-content .button" */
+    font-size: 20px;
+    padding: 3px 13px;
+    line-height: 32px;
+    border-radius: 3px;
 }

--- a/pos_payment_terminal/static/src/xml/pos_payment_terminal.xml
+++ b/pos_payment_terminal/static/src/xml/pos_payment_terminal.xml
@@ -13,7 +13,11 @@
     <t t-extend="PaymentScreen-Paymentlines" >
         <t t-jquery=".col-name" t-operation="append">
             <t t-if="line.cashregister.journal.pos_terminal_payment_mode and widget.pos.config.iface_payment_terminal">
-                   <button class="payment-terminal-transaction-start"  t-att-data-cid='line.cid'>Start transaction</button>
+                   <button class="payment-terminal-transaction-start" t-att-data-cid="line.cid"
+                        title="Start transaction">
+                        <i class="fa fa-credit-card" />
+                        <i class="fa fa-share-square" />
+                    </button>
             </t>
         </t>
     </t>


### PR DESCRIPTION
following https://github.com/OCA/pos/pull/544#issuecomment-705175575

- replace small button by bigger button
- use default point of sale css
- include fa icon

**Before :** 

![image](https://user-images.githubusercontent.com/3407482/98958084-32f4d300-2502-11eb-828e-af8410092791.png)


**After :** 

![image](https://user-images.githubusercontent.com/3407482/98958105-38eab400-2502-11eb-9eed-bd97d13f6d47.png)

The text "Start transaction" is still present in the title of the button.


CC : @alexis-via , @ivantodorovich 
CC : @grap, @quentinDupont, @sandiefavre 
