### PR TITLE
 [FIX] pos_meal_voucher: remove unoverloadable function.

### DIFF
--- a/pos_meal_voucher/static/src/js/screens.js
+++ b/pos_meal_voucher/static/src/js/screens.js
@@ -121,38 +121,6 @@ odoo.define("pos_meal_voucher.screens", function (require) {
 
         },
 
-        order_is_valid: function(force_validation) {
-            var self = this;
-            var order = this.pos.get_order();
-
-            var total_eligible = order.get_total_meal_voucher_eligible();
-            var total_received = order.get_total_meal_voucher_received();
-            var max_amount = this.pos.config.max_meal_voucher_amount;
-
-            var current_max = total_eligible;
-            if (max_amount) {
-                current_max = Math.min(total_eligible, max_amount);
-            }
-
-            // if the change is too large, it's probably an input error, make the user confirm.
-            if (!force_validation && (total_received > current_max)) {
-                this.gui.show_popup("confirm", {
-                    title: _t("Please Confirm Meal Voucher Amount"),
-                    body:  _t("You are about to validate a meal voucher payment of ") +
-                           this.format_currency(total_received) +
-                           _t(", when the maximum amount is ") +
-                           this.format_currency(current_max) +
-                           _t(".\n\n Clicking 'Confirm' will validate the payment."),
-                    confirm: function() {
-                        // Note: Due to the bad design of the original function
-                        // the check "Large Amount" will be skipped in that case.
-                        self.validate_order("confirm");
-                    },
-                });
-                return false;
-            }
-            return this._super.apply(this, arguments);;
-        },
     });
 
 });


### PR DESCRIPTION
the function that the PR remove is not overloable with that way. More precisely it fails if there is a confirm action inside due to the poor design of odoo Point of sale. 
the same patch should be applied in ``pos_tare``. 

Step to reproduce : 
- install pos_tare and pos_meal_voucher.
- open the PoS and try to confirm an action with wrong values. (negative quantity AND to much meal voucher to receive). 
- it's not possible to confirm the order, even if we click on confirm. (infinite loop of confirmation).

CC : @grap : #/board/144/card/1099 @quentinDupont 

CC : @Fkawala