### PR TITLE
 [FIX] pos_tare : raise an error if the gross weight is not correct

### DIFF
--- a/pos_tare/static/src/js/screens.js
+++ b/pos_tare/static/src/js/screens.js
@@ -80,6 +80,12 @@ odoo.define('pos_tare.screens', function (require) {
                     'body': _t('Please set a numeric value' +
                         ' in the tare field, or let empty.'),
                 });
+            } else if (isNaN(this.gross_weight)) {
+                this.gui.show_popup('error', {
+                    'title': _t('Incorrect Gross Weight Value'),
+                    'body': _t('Please set a numeric value' +
+                        ' in the gross weight field.'),
+                });
             } else {
                 this._super();
                 if (this.tare > 0.0) {
@@ -180,7 +186,7 @@ odoo.define('pos_tare.screens', function (require) {
                 } else if (mode === 'tare') {
                     if (this.pos.config.iface_tare_method === 'barcode') {
                         this.gui.show_popup('error',
-                            {'title': _t('Incorrect Tare Value'),
+                            {'title': _t('Feature Disabled'),
                                 'body': _t('You can not set the tare.' +
                                 ' To be able to set the tare manually' +
                                 ' you have to change the tare input method' +


### PR DESCRIPTION
Raise an error if the gross weight is not correct.

Exemple : 

![image](https://user-images.githubusercontent.com/3407482/99259355-28944b00-281a-11eb-8e1c-c661261d62a8.png)

**before the patch**

- a pos order line is added silently, with a qty to 0.

**After the patch**

- an error is raised.

![image](https://user-images.githubusercontent.com/3407482/99259424-495ca080-281a-11eb-91b0-572f71962e8c.png)


(Also fix an bad title for another warning).

CC : 
- @grap, @quentinDupont, @sandiefavre (Ref : #/board/144/card/1080)
- @Fkawala 