### PR TITLE
 [IMP] pos_meal_voucher : do not display meal voucher features, if there are no meal voucher journal

### DIFF
--- a/pos_meal_voucher/models/pos_config.py
+++ b/pos_meal_voucher/models/pos_config.py
@@ -16,3 +16,11 @@ class PosConfig(models.Model):
     meal_voucher_display_product_screen = fields.Boolean(
         string="Display icon before products on screen",
         default=True)
+
+    has_meal_voucher_journal = fields.Boolean(
+        compute="_compute_has_meal_voucher_journal")
+
+    def _compute_has_meal_voucher_journal(self):
+        for config in self:
+            config.has_meal_voucher_journal = len(config.journal_ids.filtered(
+                lambda x: x.meal_voucher_type is not False))

--- a/pos_meal_voucher/static/src/js/screens.js
+++ b/pos_meal_voucher/static/src/js/screens.js
@@ -53,7 +53,7 @@ odoo.define("pos_meal_voucher.screens", function (require) {
         update_summary: function () {
             this._super.apply(this, arguments);
             var order = this.pos.get_order();
-            if (!order.get_orderlines().length) {
+            if (!order.get_orderlines().length || !this.pos.config.has_meal_voucher_journal) {
                 return;
             }
             this.el.querySelector(".summary .meal-voucher .value").textContent = this.format_currency(order.get_total_meal_voucher_eligible());
@@ -93,7 +93,7 @@ odoo.define("pos_meal_voucher.screens", function (require) {
 
             this._super.apply(this, arguments);
             var order = this.pos.get_order();
-            if (!order) {
+            if (!order || !this.pos.config.has_meal_voucher_journal) {
                 return;
             }
             // Update meal voucher summary

--- a/pos_meal_voucher/static/src/xml/pos_meal_voucher.xml
+++ b/pos_meal_voucher/static/src/xml/pos_meal_voucher.xml
@@ -12,9 +12,11 @@
 
     <t t-extend="OrderWidget">
         <t t-jquery="div.line" t-operation="append">
-            <div class="meal-voucher">
-                (<span>Meal Voucher: </span> <span class="value">0.00 €</span>)
-            </div>
+            <t t-if="widget.pos.config.has_meal_voucher_journal">
+                <div class="meal-voucher">
+                    (<span>Meal Voucher: </span> <span class="value">0.00 €</span>)
+                </div>
+            </t>
         </t>
     </t>
 
@@ -32,6 +34,7 @@
             </t>
         </t>
         <t t-jquery="div.paymentmethods" t-operation="after">
+            <t t-if="widget.pos.config.has_meal_voucher_journal">
             <div class="meal-voucher-summary">
                 <table class="meal-voucher-summary">
                     <thead>
@@ -65,6 +68,7 @@
                     </tbody>
                 </table>
             </div>
+            </t>
         </t>
     </t>
 


### PR DESCRIPTION
merge type : minor

summary : in a multicompany context, if some pos.config has no journals with meal voucher, all the features and text will be displayed, that is useless.
this PR hide all the meal voucher section, if no journal are set as "meal voucher".

CC : @grap, @quentinDupont ref #/board/144/card/1099