### PR TITLE
 [FIX] pos_payment_change : Add ondelete cascade to avoid error when cleaning transient model tables

### DIFF
--- a/pos_payment_change/wizards/pos_payment_change_wizard_new_line.py
+++ b/pos_payment_change/wizards/pos_payment_change_wizard_new_line.py
@@ -11,6 +11,7 @@ class PosPaymentChangeWizardLine(models.TransientModel):
 
     wizard_id = fields.Many2one(
         comodel_name="pos.payment.change.wizard", required=True,
+        ondelete='cascade'
     )
 
     new_journal_id = fields.Many2one(

--- a/pos_payment_change/wizards/pos_payment_change_wizard_old_line.py
+++ b/pos_payment_change/wizards/pos_payment_change_wizard_old_line.py
@@ -11,6 +11,7 @@ class PosPaymentChangeWizardOldLine(models.TransientModel):
 
     wizard_id = fields.Many2one(
         comodel_name="pos.payment.change.wizard", required=True,
+        ondelete='cascade'
     )
 
     old_journal_id = fields.Many2one(


### PR DESCRIPTION
Trivial patch to avoid the following  error when autovacuum is launched.

```Failed to clean transient model pos.payment.change.wizard()
null value in column "wizard_id" violates not-null constraint
DETAIL:  Failing row contains (194, null, 247, null, 106.58, 125, 2020-12-22 17:57:12.03472, 125, 2020-12-22 17:57:12.03472).
CONTEXT:  SQL statement "UPDATE ONLY "public"."pos_payment_change_wizard_new_line" SET "wizard_id" = NULL WHERE $1 OPERATOR(pg_catalog.=) "wizard_id""```

