### PR TITLE
 [FIX] pos_payment_change: use original date_order for the new orders and the payments

### DIFF
--- a/pos_payment_change/models/pos_order.py
+++ b/pos_payment_change/models/pos_order.py
@@ -5,7 +5,7 @@
 
 from datetime import datetime
 
-from odoo import _, api, fields, models
+from odoo import _, api, models
 from odoo.tools import float_is_zero
 from odoo.exceptions import Warning as UserError
 
@@ -57,11 +57,16 @@ class PosOrder(models.Model):
             refund_result = self.refund()
             refund_order = self.browse(refund_result["res_id"])
 
+            refund_order.write({
+                "date_order": self.date_order,
+                "session_id": self.session_id.id,
+                })
+
             for statement in self.statement_ids:
                 refund_order.add_payment({
                     "journal": statement.journal_id.id,
                     "amount": - statement.amount,
-                    "payment_date": fields.Date.context_today(self),
+                    "payment_date": self.date_order,
                 })
             refund_order.action_pos_order_paid()
 

--- a/pos_payment_change/wizards/pos_payment_change_wizard.py
+++ b/pos_payment_change/wizards/pos_payment_change_wizard.py
@@ -74,7 +74,7 @@ class PosPaymentChangeWizard(models.TransientModel):
         new_payments = [{
             "journal": line.new_journal_id.id,
             "amount": line.amount,
-            "payment_date": fields.Date.context_today(self),
+            "payment_date": self.order_id.date_order,
         } for line in self.new_line_ids]
 
         orders = order.change_payment(new_payments)


### PR DESCRIPTION
### in "update" mode

**Before** 
- the payment lines have the date of the correction.

**After**
- the payments lines have the date of the original order.

### in "refund" mode 

**Before** 
- the refund order doesn't have the correct session and have the date of the correction

** After**
- the refund order doesn't have the same session and the same date as the original order.

CC : @quentinDupont  (board/144/card/1243)
