### PR TITLE
[14.0] Add module pos_no_cash_bank_statement

### DIFF
--- a/pos_no_cash_bank_statement/__init__.py
+++ b/pos_no_cash_bank_statement/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/pos_no_cash_bank_statement/__manifest__.py
+++ b/pos_no_cash_bank_statement/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright 2021 Akretion France (http://www.akretion.com/)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "POS No Cash Bank Statement",
+    "version": "14.0.1.0.0",
+    "category": "Sales/Point of Sale",
+    "license": "AGPL-3",
+    "summary": "Generate bank statements for all payment methods, not only cash",
+    "author": "Akretion,Odoo Community Association (OCA)",
+    "maintainers": ["alexis-via"],
+    "website": "https://github.com/OCA/pos",
+    "depends": ["point_of_sale"],
+    "data": [
+        "views/pos_payment_method.xml",
+    ],
+    "installable": True,
+}

--- a/pos_no_cash_bank_statement/models/__init__.py
+++ b/pos_no_cash_bank_statement/models/__init__.py
@@ -1,0 +1,2 @@
+from . import pos_payment_method
+from . import pos_session

--- a/pos_no_cash_bank_statement/models/pos_payment_method.py
+++ b/pos_no_cash_bank_statement/models/pos_payment_method.py
@@ -1,0 +1,76 @@
+# Copyright 2021 Akretion France (http://www.akretion.com/)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class PosPaymentMethod(models.Model):
+    _inherit = "pos.payment.method"
+
+    cash_journal_id = fields.Many2one(
+        domain=[("type", "in", ("bank", "cash"))],
+        string="Bank/Cash Journal",
+    )
+    journal_type_domain = fields.Char(compute="_compute_journal_type_domain")
+    bank_statement = fields.Boolean(
+        string="Generate Bank Statement",
+        help="By default, Odoo will generate a cash register/bank statement "
+        "upon POS session closing only for cash payment methods. If you enable "
+        "this option for a non-cash payment method, Odoo will generate a bank "
+        "statement upon session closing, which will generate accounting entries "
+        "in the bank journal, which will be automatically reconciled with the "
+        "sale journal entry.",
+    )
+
+    @api.constrains("is_cash_count", "cash_journal_id", "bank_statement")
+    def _check_journal_config(self):
+        for method in self:
+            if method.is_cash_count:
+                if not method.cash_journal_id:
+                    raise ValidationError(
+                        _("Missing cash journal on cash payment method '%s'.")
+                        % method.display_name
+                    )
+                if method.cash_journal_id.type != "cash":
+                    raise ValidationError(
+                        _(
+                            "The journal configured on the cash payment method '%s' "
+                            "should be a cash journal."
+                        )
+                        % method.display_name
+                    )
+            elif method.bank_statement:
+                if not method.cash_journal_id:
+                    raise ValidationError(
+                        _("Missing bank journal on payment method '%s'.")
+                        % method.display_name
+                    )
+                if method.cash_journal_id.type != "bank":
+                    raise ValidationError(
+                        _(
+                            "The journal configured on the payment method '%s' "
+                            "should be a bank journal."
+                        )
+                        % method.display_name
+                    )
+
+    # Updating domain via onchange is deprecated in odoo v14
+    # That's why I use this computed field
+    @api.depends("is_cash_count")
+    def _compute_journal_type_domain(self):
+        for method in self:
+            if method.is_cash_count:
+                method.journal_type_domain = "cash"
+            else:
+                method.journal_type_domain = "bank"
+
+    @api.onchange("is_cash_count")
+    def is_cash_count_change(self):
+        if self.is_cash_count:
+            self.bank_statement = False
+            self.cash_journal_id = False
+        else:
+            self.cash_journal_id = False

--- a/pos_no_cash_bank_statement/models/pos_session.py
+++ b/pos_no_cash_bank_statement/models/pos_session.py
@@ -1,0 +1,60 @@
+# Copyright 2021 Akretion France (http://www.akretion.com/)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class PosSession(models.Model):
+    _inherit = "pos.session"
+
+    def _accumulate_amounts(self, data):
+        data = super()._accumulate_amounts(data)
+        # IDEA : move split_receivables and combine_receivables to
+        # split_receivables_cash and combine_receivables_cash
+        # if bank_statement is true on pos.payment.method
+        # The big advantage of this implementation is that
+        # there is no need to re-implement the logic of
+        # _create_cash_statement_lines_and_cash_move_lines()
+        # and update _reconcile_account_move_lines()
+        # The drawback is that we store the bank journal for the non
+        # cash method payment in the native field cash_journal_id
+        # which is a bit "strange"
+        # I have to do that because the method
+        # _create_cash_statement_lines_and_cash_move_lines()
+        # reads payment_method_id.cash_journal_id
+        payment_methods_bank_statement = self.env["pos.payment.method"].search(
+            [
+                ("is_cash_count", "=", False),
+                ("bank_statement", "=", True),
+                ("cash_journal_id", "!=", False),
+            ]
+        )
+        if payment_methods_bank_statement:
+            self.write(
+                {
+                    "statement_ids": [
+                        (
+                            0,
+                            0,
+                            {
+                                "journal_id": pay_method.cash_journal_id.id,
+                                "name": self.name,
+                            },
+                        )
+                        for pay_method in payment_methods_bank_statement
+                    ]
+                }
+            )
+            # I can't pop data['split_receivables'] inside a loop on
+            # data['split_receivables'],
+            # that's why I use dict(data['split_receivables'])
+            for pos_payment, value in dict(data["split_receivables"]).items():
+                if pos_payment.payment_method_id in payment_methods_bank_statement:
+                    data["split_receivables_cash"][pos_payment] = value
+                    data["split_receivables"].pop(pos_payment)
+            for pos_payment_method, value in dict(data["combine_receivables"]).items():
+                if pos_payment_method in payment_methods_bank_statement:
+                    data["combine_receivables_cash"][pos_payment_method] = value
+                    data["combine_receivables"].pop(pos_payment_method)
+        return data

--- a/pos_no_cash_bank_statement/readme/CONTRIBUTORS.rst
+++ b/pos_no_cash_bank_statement/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Alexis de Lattre <alexis.delattre@akretion.com>

--- a/pos_no_cash_bank_statement/readme/DESCRIPTION.rst
+++ b/pos_no_cash_bank_statement/readme/DESCRIPTION.rst
@@ -1,0 +1,5 @@
+Up to Odoo 12.0, POS sessions generated bank statements for each payment method and therefore closing a POS session would generate payment journal entries for all payment methods.
+
+In Odoo 13.0 and upper, only the cash payment method generate a cash register/bank statement and therefore the payment journal entries. The non-cash payment methods don't generate any payment journal entries.
+
+With this module, you have a new option **Generate Bank Statement** on non-cash POS payment method. If you enable that option, Odoo will generate a bank statement and will generate the payment journal entries upon POS session closing. For example, if your POS accepts payment by check, you certainly want to enable that option for the *Check* POS payment method.

--- a/pos_no_cash_bank_statement/views/pos_payment_method.xml
+++ b/pos_no_cash_bank_statement/views/pos_payment_method.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright 2021 Akretion France (http://www.akretion.com/)
+  @author: Alexis de Lattre <alexis.delattre@akretion.com>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+<record id="pos_payment_method_view_form" model="ir.ui.view">
+    <field name="model">pos.payment.method</field>
+    <field name="inherit_id" ref="point_of_sale.pos_payment_method_view_form" />
+    <field name="arch" type="xml">
+        <field name="cash_journal_id" position="before">
+            <field name="journal_type_domain" invisible="1" />
+            <field
+                    name="bank_statement"
+                    attrs="{'invisible': [('is_cash_count', '=', True)]}"
+                />
+        </field>
+        <field name="cash_journal_id" position="attributes">
+            <attribute
+                    name="attrs"
+                >{'invisible': [('is_cash_count', '=', False), ('bank_statement', '=', False)], 'required': ['|', ('is_cash_count', '=', True), ('bank_statement', '=', True)]}</attribute>
+            <attribute
+                    name="domain"
+                >[('company_id', '=', company_id), ('type', '=', journal_type_domain)]</attribute>
+        </field>
+    </field>
+</record>
+
+</odoo>

--- a/setup/pos_no_cash_bank_statement/odoo/addons/pos_no_cash_bank_statement
+++ b/setup/pos_no_cash_bank_statement/odoo/addons/pos_no_cash_bank_statement
@@ -1,0 +1,1 @@
+../../../../pos_no_cash_bank_statement

--- a/setup/pos_no_cash_bank_statement/setup.py
+++ b/setup/pos_no_cash_bank_statement/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
About this new module:

Up to Odoo 12.0, POS sessions generated bank statements for each payment method and therefore closing a POS session would generate payment journal entries for all payment methods.

In Odoo 13.0 and upper, only the cash payment method generate a cash register/bank statement and therefore the payment journal entries. The non-cash payment methods don't generate any payment journal entries.

With this module, you have a new option **Generate Bank Statement** on non-cash POS payment method. If you enable that option, Odoo will generate a bank statement and will generate the payment journal entries upon POS session closing. For example, if your POS accepts payment by check, you certainly want to enable that option for the *Check* POS payment method.