### PR TITLE
[14.0] pos_payment_terminal: manage terminal transaction status

### DIFF
--- a/pos_payment_terminal/__manifest__.py
+++ b/pos_payment_terminal/__manifest__.py
@@ -8,7 +8,13 @@
     "version": "14.0.1.0.0",
     "category": "Point Of Sale",
     "summary": "Point of sale: support generic payment terminal",
-    "author": "Aurélien DUMAINE,GRAP,Akretion," "Odoo Community Association (OCA)",
+    "author": (
+        "Aurélien DUMAINE,"
+        "GRAP,"
+        "Akretion,"
+        "ACSONE SA/NV,"
+        "Odoo Community Association (OCA)"
+    ),
     "website": "https://github.com/OCA/pos",
     "license": "AGPL-3",
     "depends": ["point_of_sale"],

--- a/pos_payment_terminal/models/pos_payment_method.py
+++ b/pos_payment_terminal/models/pos_payment_method.py
@@ -16,3 +16,10 @@ class PosPaymentMethod(models.Model):
     oca_payment_terminal_mode = fields.Selection(
         [("card", "Card"), ("check", "Check")], string="Payment Mode", default="card"
     )
+    oca_payment_terminal_id = fields.Char(
+        string="Terminal identifier",
+        help=(
+            "The identifier of the terminal as known by the hardware proxy. "
+            "Leave empty if the proxy has only one terminal connected."
+        ),
+    )

--- a/pos_payment_terminal/static/src/js/models.js
+++ b/pos_payment_terminal/static/src/js/models.js
@@ -4,6 +4,8 @@
     Copyright (C) 2014-2020 Akretion (www.akretion.com)
     @author: Aurélien DUMAINE
     @author: Alexis de Lattre <alexis.delattre@akretion.com>
+    @author: Denis Roussel <denis.roussel@acsone.eu>
+    @author: Stéphane Bidoul <stephane.bidoul@acsone.eu>
     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 */
 
@@ -11,7 +13,40 @@ odoo.define("pos_payment_terminal.models", function (require) {
     "use strict";
 
     var models = require("point_of_sale.models");
+
     var OCAPaymentTerminal = require("pos_payment_terminal.payment");
     models.register_payment_method("oca_payment_terminal", OCAPaymentTerminal);
     models.load_fields("pos.payment.method", "oca_payment_terminal_mode");
+
+    var _paymentlineproto = models.Paymentline.prototype;
+    models.Paymentline = models.Paymentline.extend({
+        initialize: function () {
+            _paymentlineproto.initialize.apply(this, arguments);
+            // Id of the terminal transaction, used to find the payment
+            // line corresponding to a terminal transaction status coming
+            // from the terminal driver.
+            this.terminal_transaction_id = null;
+            // Success: null: in progress, false: failed: true: succeeded
+            this.terminal_transaction_success = null;
+            // Human readable transaction status, set if the transaction failed.
+            this.terminal_transaction_status = null;
+            // Additional information about the transaction status.
+            this.terminal_transaction_status_details = null;
+        },
+        init_from_JSON: function (json) {
+            _paymentlineproto.init_from_JSON.apply(this, arguments);
+            this.terminal_transaction_id = json.terminal_transaction_id;
+            this.terminal_transaction_success = json.terminal_transaction_success;
+            this.terminal_transaction_status = json.terminal_transaction_status;
+            this.terminal_transaction_status_details =
+                json.terminal_transaction_status_details;
+        },
+        export_as_JSON: function () {
+            var vals = _paymentlineproto.export_as_JSON.apply(this, arguments);
+            vals.terminal_transaction_id = this.terminal_transaction_id;
+            vals.terminal_transaction_success = this.terminal_transaction_success;
+            vals.terminal_transaction_status_details = this.terminal_transaction_status_details;
+            return vals;
+        },
+    });
 });

--- a/pos_payment_terminal/static/src/js/models.js
+++ b/pos_payment_terminal/static/src/js/models.js
@@ -16,7 +16,10 @@ odoo.define("pos_payment_terminal.models", function (require) {
 
     var OCAPaymentTerminal = require("pos_payment_terminal.payment");
     models.register_payment_method("oca_payment_terminal", OCAPaymentTerminal);
-    models.load_fields("pos.payment.method", "oca_payment_terminal_mode");
+    models.load_fields("pos.payment.method", [
+        "oca_payment_terminal_mode",
+        "oca_payment_terminal_id",
+    ]);
 
     var _paymentlineproto = models.Paymentline.prototype;
     models.Paymentline = models.Paymentline.extend({

--- a/pos_payment_terminal/static/src/js/models.js
+++ b/pos_payment_terminal/static/src/js/models.js
@@ -26,7 +26,7 @@ odoo.define("pos_payment_terminal.models", function (require) {
         after_load_server_data: function () {
             for (var payment_method_id in this.payment_methods) {
                 var payment_method = this.payment_methods[payment_method_id];
-                if ((payment_method.use_payment_terminal = "oca_payment_terminal")) {
+                if (payment_method.use_payment_terminal == "oca_payment_terminal") {
                     this.config.use_proxy = true;
                 }
             }

--- a/pos_payment_terminal/static/src/js/models.js
+++ b/pos_payment_terminal/static/src/js/models.js
@@ -21,6 +21,19 @@ odoo.define("pos_payment_terminal.models", function (require) {
         "oca_payment_terminal_id",
     ]);
 
+    var _posmodelproto = models.PosModel.prototype;
+    models.PosModel = models.PosModel.extend({
+        after_load_server_data: function () {
+            for (var payment_method_id in this.payment_methods) {
+                var payment_method = this.payment_methods[payment_method_id];
+                if ((payment_method.use_payment_terminal = "oca_payment_terminal")) {
+                    this.config.use_proxy = true;
+                }
+            }
+            return _posmodelproto.after_load_server_data.apply(this, arguments);
+        },
+    });
+
     var _paymentlineproto = models.Paymentline.prototype;
     models.Paymentline = models.Paymentline.extend({
         initialize: function () {

--- a/pos_payment_terminal/static/src/js/payment_terminal.js
+++ b/pos_payment_terminal/static/src/js/payment_terminal.js
@@ -43,6 +43,9 @@ odoo.define("pos_payment_terminal.payment", function (require) {
                 payment_id: pay_line.cid,
                 order_id: order.name,
             };
+            if (this.payment_method.oca_payment_terminal_id) {
+                data.terminal_id = this.payment_method.oca_payment_terminal_id;
+            }
             return this._oca_payment_terminal_proxy_request(data).then((response) => {
                 if (response === false) {
                     this._show_error(
@@ -85,8 +88,15 @@ odoo.define("pos_payment_terminal.payment", function (require) {
                 // Query the driver status more frequently than the regular POS
                 // proxy, to get faster feedback when the transaction is
                 // complete on the terminal.
+                var status_params = {};
+                if (this.payment_method.oca_payment_terminal_id) {
+                    status_params.terminal_id = this.payment_method.oca_payment_terminal_id;
+                }
                 this.pos.proxy.connection
-                    .rpc("/hw_proxy/status_json", {}, {shadow: true, timeout: 1000})
+                    .rpc("/hw_proxy/status_json", status_params, {
+                        shadow: true,
+                        timeout: 1000,
+                    })
                     .then((drivers_status) => {
                         for (var driver_name in drivers_status) {
                             // Look for a driver that is a payment terminal and has

--- a/pos_payment_terminal/static/src/js/payment_terminal.js
+++ b/pos_payment_terminal/static/src/js/payment_terminal.js
@@ -71,12 +71,8 @@ odoo.define("pos_payment_terminal.payment", function (require) {
                 .then((response) => {
                     return response;
                 })
-                .catch((error) => {
-                    console.error(
-                        "Error starting payment transaction:",
-                        error,
-                        error.stack
-                    );
+                .catch(() => {
+                    console.error("Error starting payment transaction");
                     return false;
                 });
         },

--- a/pos_payment_terminal/views/pos_payment_method.xml
+++ b/pos_payment_terminal/views/pos_payment_method.xml
@@ -10,6 +10,10 @@
                     name="oca_payment_terminal_mode"
                     attrs="{'invisible': [('use_payment_terminal', '!=', 'oca_payment_terminal')]}"
                 />
+                <field
+                    name="oca_payment_terminal_id"
+                    attrs="{'invisible': [('use_payment_terminal', '!=', 'oca_payment_terminal')]}"
+                />
             </field>
         </field>
     </record>


### PR DESCRIPTION
This PR is based on #572. Only the last 3 commit are relevant.

It adds support for
- waiting for the transaction status as reported by the terminal (including the transaction reference for accounting reconciliation)
- multiple terminals managed by the same hardware proxy

This can be tested using `pywebdriver` and it's `payment_mock_driver` where you can confirm or reject transactions on the command line.