### PR TITLE
[FIX] Fixed order date tz bug. Fixed payment lines bug.

### DIFF
--- a/pos_order_mgmt/models/pos_order.py
+++ b/pos_order_mgmt/models/pos_order.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, fields, models
+import pytz
 
 
 class PosOrder(models.Model):
@@ -110,9 +111,12 @@ class PosOrder(models.Model):
         for payment_line in self.payment_ids:
             payment_line = self._prepare_done_order_payment_for_pos(payment_line)
             payment_lines.append(payment_line)
+        tz = self.env.user.tz
+        date_order_utc = pytz.UTC.localize(self.date_order)
+        date_order_tz = date_order_utc.astimezone(pytz.timezone(tz))
         res = {
             "id": self.id,
-            "date_order": self.date_order,
+            "date_order": date_order_tz,
             "pos_reference": self.pos_reference,
             "name": self.name,
             "partner_id": self.partner_id.id,
@@ -138,7 +142,7 @@ class PosOrder(models.Model):
     def _prepare_done_order_payment_for_pos(self, payment_line):
         self.ensure_one()
         return {
-            "journal_id": payment_line.pos_order_id.sale_journal,
+            "payment_method_id": payment_line.payment_method_id.id,
             "amount": payment_line.amount,
         }
 

--- a/pos_order_mgmt/static/src/js/widgets.js
+++ b/pos_order_mgmt/static/src/js/widgets.js
@@ -13,6 +13,7 @@ odoo.define("pos_order_mgmt.widgets", function(require) {
     var gui = require("point_of_sale.gui");
     var chrome = require("point_of_sale.chrome");
     var models = require("point_of_sale.models");
+    var field_utils = require('web.field_utils');
 
     var QWeb = core.qweb;
     var ScreenWidget = screens.ScreenWidget;
@@ -262,9 +263,8 @@ odoo.define("pos_order_mgmt.widgets", function(require) {
 
             // Get Date
             if (["print"].indexOf(action) !== -1) {
-                order.formatted_validation_date = moment(order_data.date_order).format(
-                    "YYYY-MM-DD HH:mm:ss"
-                );
+                order.formatted_validation_date = field_utils.format.datetime(
+                    moment(order_data.date_order), {}, {timezone: false});
             }
 
             // Get Payment lines
@@ -276,15 +276,11 @@ odoo.define("pos_order_mgmt.widgets", function(require) {
                     if (line.length === 3) {
                         line = line[2];
                     }
-                    _.each(self.pos.cashregisters, function(cashregister) {
-                        if (cashregister.journal.id === line.journal_id) {
-                            if (line.amount > 0) {
-                                // If it is not change
-                                order.add_paymentline(cashregister);
-                                order.selected_paymentline.set_amount(line.amount);
-                            }
-                        }
-                    });
+                    if ((self.pos.payment_methods_by_id[line.payment_method_id]) && (line.amount > 0)) {
+                        // If it is not change
+                        order.add_paymentline(self.pos.payment_methods_by_id[line.payment_method_id]);
+                        order.selected_paymentline.set_amount(line.amount);
+                    }
                 });
             }
             return order;


### PR DESCRIPTION
Two bugs:
 - order date should be in tz of current user - and get formatted according the local datetime format
 - paymentlines do not use cashregister in v13 - use payment method instead