### PR TITLE
 [FIX] pos_multiple_control : fix compatibility with pos_session_pay_invoice. hide buttons instead of removing them

### DIFF
--- a/pos_multiple_control/views/view_pos_session.xml
+++ b/pos_multiple_control/views/view_pos_session.xml
@@ -17,9 +17,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                 <attribute name="readonly">1</attribute>
             </field>
 
-            <!-- Hide obsolete Buttons -->
-            <!-- Same name button for opening and closing.. -->
-            <xpath expr="//button[@name='open_cashbox']" position="replace">
+            <xpath expr="//button[@name='open_cashbox']" position="after">
                 <button name="open_cashbox_opening"
                     class="oe_stat_button"
                     attrs="{'invisible':['|', ('cash_control', '=', False), ('state', '!=', 'opening_control')]}"
@@ -28,13 +26,17 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     <span class="o_stat_text">Set Opening Balance</span>
                 </button>
             </xpath>
-            <!-- Hide closing button -->
-            <xpath expr="//button[@name='open_cashbox']" position="replace">
+            <!-- Hide obsolete opening and closing button that have same name-->
+            <xpath expr="//button[@name='open_cashbox'][1]" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="//button[@name='open_cashbox'][2]" position="attributes">
+                <attribute name="invisible">1</attribute>
             </xpath>
 
             <!-- Add new session button on closing-->
             <xpath expr="//header" position="inside">
-                <button name="action_pos_session_new_session" type="object" 
+                <button name="action_pos_session_new_session" type="object"
                     string="New Session" class="oe_highlight"
                     attrs="{'invisible' : [('state', '!=', 'closed')]}"/>
             </xpath>


### PR DESCRIPTION
**Rational**

- ``pos_multiple_control`` is removing (with attribute='replace') two buttons. Ref : https://github.com/OCA/pos/blob/12.0/pos_multiple_control/views/view_pos_session.xml#L22
- ``pos_session_pay_invoice`` adds items based on the two removed buttons. Ref : https://github.com/OCA/pos/blob/12.0/pos_session_pay_invoice/views/pos_session.xml#L22

So depending on the order of the installation (and the load of the module) the modules are incompatible.

the trivial patch fixes the problem.

CC : @quentinDupont 

apps/deck/#/board/144/card/1383


