### PR TITLE
Modified the Document of Origin in pos_order.py of module pos_order_return

### DIFF
--- a/pos_order_return/models/pos_order.py
+++ b/pos_order_return/models/pos_order.py
@@ -51,9 +51,9 @@ class PosOrder(models.Model):
         if not self.returned_order_id.invoice_id:
             return res
         res.update({
-            'origin': self.returned_order_id.invoice_id.number,
+            'origin': self.returned_order_id.invoice_id.document_number,
             'name': _(
-                'Return of %s' % self.returned_order_id.invoice_id.number),
+                'Return of %s' % self.returned_order_id.invoice_id.document_number),
             'refund_invoice_id': self.returned_order_id.invoice_id.id,
         })
         return res


### PR DESCRIPTION
Modified the document of origin in the module to reproduce the behaviour of the frontend when creating a return out of an invoice with the wizzard.
With these changes the Document of Origin will be the actual document number instead of the Journal movement ID