### PR TITLE
[13.0][FIX] pos_fix_search_limit

### DIFF
--- a/pos_fix_search_limit/readme/CONTRIBUTORS.rst
+++ b/pos_fix_search_limit/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Raphaël Reverdy <raphael.reverdy@akretion.com> (https://www.akretion.com)
 * David Alonso <david.alonso@solvos.es>
 * Dhara Solanki <dhara.solanki@initos.com>
+* Iván Todorovich <ivan.todorovich@gmail.com>

--- a/pos_fix_search_limit/static/src/js/pos_fix_search_limit.js
+++ b/pos_fix_search_limit/static/src/js/pos_fix_search_limit.js
@@ -21,6 +21,9 @@ odoo.define("pos_fix_search_limit.product_list", function(require) {
             // (db.limit has been increased to return more results)
             // (but we still want to limit the display)
             // And make use of document fragment, because better perfs
+            if (!this.product_list.length) {
+                return this._super.apply(this, arguments);
+            }
             var i = 0;
             var len = Math.min(this.product_list.length, this.displayLimit);
             var frag = document.createDocumentFragment();


### PR DESCRIPTION
`.product-list` may not be present after rendering.

This happens when the list is empty, as seen in core code:
https://github.com/odoo/odoo/blob/dcb6a3cea27f32d722d1a8dc87c34a846cf5ac23/addons/point_of_sale/static/src/xml/pos.xml#L257

The element is displayed only if `product_list.length != 0`.


---

Besides it being a rare to see bug (product list has to be empty), it causes a compatibility issue with `pos_empty_home` and when they're both installed an error will prevent the ui from rendering properly:

![image](https://user-images.githubusercontent.com/1914185/117700327-3eb50f80-b19c-11eb-93f8-80799b86352d.png)

This also affects other modules tours that run in travis ci 