### PR TITLE
 [FIX] pos_payment_terminal : order is undefined in the table screen

### DIFF
--- a/pos_payment_terminal/static/src/js/devices.js
+++ b/pos_payment_terminal/static/src/js/devices.js
@@ -24,6 +24,9 @@ odoo.define('pos_payment_terminal.devices', function (require) {
                 var paymentwidget = self.pos.chrome.screens.payment;
                 var drivers = status.newValue.drivers;
                 var order = self.pos.get_order();
+                if(!order) {
+                    return;
+                }
                 var in_transaction = false;
                 Object.keys(drivers).forEach(function(driver_name) {
                     if (drivers[driver_name].hasOwnProperty("in_transaction")) {


### PR DESCRIPTION
Use case : 
- install ``pos_payment_terminal`` and ``pos_restaurant``
- configure your pos.config with one (or more floor)
- launch the Point of sale 
- a non blocking JS error is raised, once the PoS is loaded

![image](https://user-images.githubusercontent.com/3407482/122895232-3548c680-d348-11eb-8936-faa5d666441c.png)


apps/deck/#/board/144/card/1687


CC : @quentinDupont 