### PR TITLE
 [FIX][12.0] pos_multiple_control : remove numeric_step widget for the field coin_value

### DIFF
--- a/pos_multiple_control/wizard/wizard_pos_update_statement_balance.xml
+++ b/pos_multiple_control/wizard/wizard_pos_update_statement_balance.xml
@@ -28,8 +28,7 @@
                                 <tree editable="bottom">
                                     <field name="currency_id" invisible="1"/>
                                     <field name="balance_moment" invisible="1"/>
-                                    <field name="coin_value" 
-                                        widget="numeric_step" options="{'step': 0.05, 'min': 0}"/>
+                                    <field name="coin_value"/>
                                     <field name="number"
                                         widget="numeric_step" options="{'step': 1, 'min': 0}"/>
                                     <field name="subtotal" sum="Balance total"


### PR DESCRIPTION
hi. 

using this module since monthes, using the widget ``numeric_step`` makes sense for the field ``number`` but is error prone and useless for the field ``coin_value``.

CC : @quentinDupont 

Ref : apps/deck/#/board/144/card/1337