### PR TITLE
 [FIX] pos_order_mgmt : conserve pricelist of the previous order, when loading the order

### DIFF
--- a/pos_order_mgmt/models/pos_order.py
+++ b/pos_order_mgmt/models/pos_order.py
@@ -120,6 +120,7 @@ class PosOrder(models.Model):
             'name': self.name,
             'partner_id': self.partner_id.id,
             'fiscal_position': self.fiscal_position_id.id,
+            'pricelist_id': self.pricelist_id.id,
             'line_ids': order_lines,
             'statement_ids': payment_lines,
             'to_invoice': bool(self.invoice_id),

--- a/pos_order_mgmt/static/src/js/widgets.js
+++ b/pos_order_mgmt/static/src/js/widgets.js
@@ -225,6 +225,12 @@ odoo.define('pos_order_mgmt.widgets', function (require) {
                     this.pos.db.get_partner_by_id(order_data.partner_id));
             }
 
+            // Get pricelist, if it is available in the current Point of Sale
+            order.set_pricelist(
+                _.findWhere(
+                    this.pos.pricelists, {'id': order_data.pricelist_id}
+                ) || this.pos.default_pricelist);
+
             // Get fiscal position
             if (order_data.fiscal_position && this.pos.fiscal_positions) {
                 var fiscal_positions = this.pos.fiscal_positions;


### PR DESCRIPTION
**Step to reproduce**

- Create an order, and set a pricelist (different than the different one)
- save the order
- duplicate / refund the order

-> the prices are correct (according to the original pricelist) : OK
-> the pricelist is not the correct one. KO.


CC : original author : @chienandalu 

Ref : apps/deck/#/board/144/card/1630 CC : @quentinDupont 