### PR TITLE
[12.0][REF] pos_picking_delayed : refactor module, due to queue_job refactoring.  + Add idempotent test

### DIFF
--- a/pos_picking_delayed/__manifest__.py
+++ b/pos_picking_delayed/__manifest__.py
@@ -15,6 +15,8 @@
         'queue_job',
     ],
     'data': [
+        'data/queue_job_channel.xml',
+        'data/queue_job_function.xml',
         'views/view_pos_config.xml',
         'views/view_pos_order.xml',
     ],

--- a/pos_picking_delayed/data/queue_job_channel.xml
+++ b/pos_picking_delayed/data/queue_job_channel.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!-- Copyright 2021 - Today Sylvain LE GAL (https://twitter.com/legalsylvain)
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).-->
+
+<odoo>
+
+    <record id="channel_pos_picking_delayed" model="queue.job.channel">
+        <field name="name">pos_picking_delayed</field>
+        <field name="parent_id" ref="queue_job.channel_root" />
+    </record>
+
+</odoo>

--- a/pos_picking_delayed/data/queue_job_function.xml
+++ b/pos_picking_delayed/data/queue_job_function.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!-- Copyright 2021 - Today Sylvain LE GAL (https://twitter.com/legalsylvain)
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).-->
+
+<odoo>
+
+    <record id="job_function_create_delayed_picking" model="queue.job.function">
+        <field name="model_id" ref="point_of_sale.model_pos_order" />
+        <field name="method">_create_delayed_picking</field>
+        <field name="channel_id" ref="channel_pos_picking_delayed"/>
+    </record>
+
+</odoo>

--- a/pos_picking_delayed/models/pos_order.py
+++ b/pos_picking_delayed/models/pos_order.py
@@ -2,7 +2,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, fields, models
-from odoo.addons.queue_job.job import job
 
 
 class PosOrder(models.Model):
@@ -43,7 +42,8 @@ class PosOrder(models.Model):
 
     # Custom Section
     @api.multi
-    @job(default_channel='root.pos_picking_delayed')
     def _create_delayed_picking(self):
-        super(PosOrder, self).create_picking()
-        self.write({'has_picking_delayed': False})
+        # make the function idempotent
+        orders = self.filtered(lambda x: x.has_picking_delayed)
+        super(PosOrder, orders).create_picking()
+        orders.write({'has_picking_delayed': False})

--- a/pos_picking_delayed/readme/CONFIGURE.rst
+++ b/pos_picking_delayed/readme/CONFIGURE.rst
@@ -7,3 +7,17 @@
 * This module depends on ``queue_job`` module that requires specific
   configuration to works properly. Make sure your config file is correctly set.
   See https://github.com/OCA/queue/tree/12.0/queue_job
+
+You should update your ``odoo.cfg`` file to add a new channel named
+``root.pos_picking_delayed``:
+
+```
+[queue_job]
+channels = root:2,root.pos_picking_delayed:1
+```
+
+Otherwise, you'll have a non blocking warning in your log, like this one.
+
+```
+WARNING ? odoo.addons.queue_job.jobrunner.channels: unknown channel root.pos_picking_delayed, using root channel for job 23f6b872-1d2c-4003-bd38-a8486bbec664
+```

--- a/pos_picking_delayed/readme/CONFIGURE.rst
+++ b/pos_picking_delayed/readme/CONFIGURE.rst
@@ -11,13 +11,14 @@
 You should update your ``odoo.cfg`` file to add a new channel named
 ``root.pos_picking_delayed``:
 
-```
-[queue_job]
-channels = root:2,root.pos_picking_delayed:1
-```
+
+.. code-block::
+
+  [queue_job]
+  channels = root:2,root.pos_picking_delayed:1
 
 Otherwise, you'll have a non blocking warning in your log, like this one.
 
-```
-WARNING ? odoo.addons.queue_job.jobrunner.channels: unknown channel root.pos_picking_delayed, using root channel for job 23f6b872-1d2c-4003-bd38-a8486bbec664
-```
+.. code-block::
+
+  WARNING ? odoo.addons.queue_job.jobrunner.channels: unknown channel root.pos_picking_delayed, using root channel for job 23f6b872-1d2c-4003-bd38-a8486bbec664


### PR DESCRIPTION
1)  refactor module, due to ``queue_job`` 12.0 refactoring. Ref : https://github.com/OCA/queue/pull/333

- remove @job decorator
- create ``queue.job.channel`` and ``queue.job.function``
- add description, regarding ``odoo.cfg`` configuration.

2) add filtered function to make sure the ``_create_delayed_picking`` function is idempotent.

@guewen : could you take a look on this PR (if possible), to make sure that the changes are correct, regarding your refactoring ? 