### PR TITLE
Automatic Stale PR/Issues workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,68 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: "0 12 * * 0"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      # 120+30 day stale policy for PRs
+      # * Except PRs marked as "no stale"
+      - name: Stale PRs policy
+        uses: actions/stale@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          exempt-pr-labels: "no stale"
+          days-before-stale: 120
+          days-before-close: 30
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          remove-stale-when-updated: true
+          stale-pr-label: "stale"
+          stale-pr-message: >
+            There hasn't been any activity on this pull request recently. It has been
+            automatically marked as stale because of that and it will be closed if no
+            further activity occurs in the next 30 days.
+
+      # 180+30 day stale policy for open issues
+      # * Except Issues marked as "no stale"
+      - name: Stale Issues policy
+        uses: actions/stale@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          exempt-issue-labels: "no stale"
+          days-before-stale: 180
+          days-before-close: 30
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          remove-stale-when-updated: true
+          stale-issue-label: "stale"
+          stale-issue-message: >
+            There hasn't been any activity on this issue in the past 6 months, so it has
+            been automatically marked as stale and it will be closed automatically if no
+            further activity occurs in the next 30 days.
+
+            If you think this is a mistake and want to keep the issue open, please ask a
+            PSC member to mark it as "no stale".
+
+      # 60+30 day stale policy for issues pending more information
+      # * Issues that are pending more information
+      # * Except Issues marked as "no stale"
+      - name: Needs more information stale issues policy
+        uses: actions/stale@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          only-labels: "needs more information"
+          exempt-issue-labels: "no stale"
+          days-before-stale: 60
+          days-before-close: 30
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          remove-stale-when-updated: true
+          stale-issue-label: "stale"
+          stale-issue-message: >
+            This issue needs more information and there hasn't been any activity for the
+            past 60 days. It will be automatically closed in 30 days unless there's some
+            activity.


### PR DESCRIPTION
ping @OCA/pos-maintainers 

Should we try this here?

To discuss policies, there's an ongoing discussion here: https://github.com/OCA/oca-addons-repo-template/pull/63