### PR TITLE
[14.0][FIX] pos_cash_move_reason: do not load account.account from demo data

### DIFF
--- a/pos_cash_move_reason/__manifest__.py
+++ b/pos_cash_move_reason/__manifest__.py
@@ -17,5 +17,4 @@
         "views/view_pos_session.xml",
         "wizard/wizard_pos_move_reason.xml",
     ],
-    "demo": ["demo/account_account.xml", "demo/pos_move_reason.xml"],
 }

--- a/pos_cash_move_reason/tests/data/account_account.xml
+++ b/pos_cash_move_reason/tests/data/account_account.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+Copyright (C) 2018 - Today: GRAP (http://www.grap.coop)
+@author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+<odoo>
+    <record id="bank_deposit_account" model="account.account">
+        <field name="code">101505</field>
+        <field name="name">Cash Awaiting Bank Deposit</field>
+        <field name="user_type_id" ref="account.data_account_type_liquidity" />
+    </record>
+    <record id="gazoline_expense_account" model="account.account">
+        <field name="code">221500</field>
+        <field name="name">Gazoline Expense</field>
+        <field name="user_type_id" ref="account.data_account_type_expenses" />
+    </record>
+</odoo>

--- a/pos_cash_move_reason/tests/data/pos_move_reason.xml
+++ b/pos_cash_move_reason/tests/data/pos_move_reason.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+Copyright (C) 2018 - Today: GRAP (http://www.grap.coop)
+@author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+<odoo>
+    <record id="bank_out_reason" model="pos.move.reason">
+        <field name="name">Bank Deposit</field>
+        <field name="is_income_reason" eval="False" />
+        <field name="is_expense_reason" eval="True" />
+        <field name="expense_account_id" ref="bank_deposit_account" />
+        <field
+            name="journal_ids"
+            model="account.journal"
+            search="[
+            ('type', '=', 'cash'),
+            ('company_id', '=', obj().env.ref('base.main_company').id),
+        ]"
+        />
+        <field name="company_id" ref="base.main_company" />
+    </record>
+    <record id="gasoline_out_reason" model="pos.move.reason">
+        <field name="name">Gazoline Expense</field>
+        <field name="is_income_reason" eval="False" />
+        <field name="is_expense_reason" eval="True" />
+        <field name="expense_account_id" ref="gazoline_expense_account" />
+        <field
+            name="journal_ids"
+            model="account.journal"
+            search="[
+            ('type', '=', 'cash'),
+            ('company_id', '=', obj().env.ref('base.main_company').id),
+        ]"
+        />
+        <field name="company_id" ref="base.main_company" />
+    </record>
+</odoo>

--- a/pos_cash_move_reason/tests/test_pos_cash_move_reason.py
+++ b/pos_cash_move_reason/tests/test_pos_cash_move_reason.py
@@ -1,14 +1,30 @@
 # © 2015 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from odoo import tools
 from odoo.exceptions import UserError
+from odoo.modules.module import get_module_resource
 from odoo.tests.common import Form, SavepointCase
+
+
+def load_file(cr, module, *args):
+    tools.convert_file(
+        cr,
+        "pos_cash_move_reason",
+        get_module_resource(module, *args),
+        {},
+        "init",
+        False,
+        "test",
+    )
 
 
 class TestPosCashMoveReason(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        load_file(cls.cr, "pos_cash_move_reason", "tests/data/", "account_account.xml")
+        load_file(cls.cr, "pos_cash_move_reason", "tests/data/", "pos_move_reason.xml")
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.PosSession = cls.env["pos.session"]
         cls.WizardReason = cls.env["wizard.pos.move.reason"]


### PR DESCRIPTION
Loading account creation from demo data could have side effect when a chart of account is loaded afterwards.
See: https://github.com/odoo/odoo/blob/14.0/addons/account/models/chart_template.py#L205