### PR TITLE
[13.0][FIX] pos_payment_terminal: Graceful cancel handling

### DIFF
--- a/pos_payment_terminal/static/src/js/payment_terminal.js
+++ b/pos_payment_terminal/static/src/js/payment_terminal.js
@@ -25,12 +25,12 @@ odoo.define("pos_payment_terminal.payment", function(require) {
 
         send_payment_cancel: function() {
             this._super.apply(this, arguments);
-            this._show_tip(
+            this._show_error(
                 _t(
-                    "Cancel the transaction by pressing the red button on the payment terminal."
+                    "Please press the red button on the payment terminal to cancel the transaction."
                 )
             );
-            return Promise.resolve();
+            return Promise.reject();
         },
 
         _oca_payment_terminal_pay: function() {
@@ -182,14 +182,6 @@ odoo.define("pos_payment_terminal.payment", function(require) {
             if (!_.isEmpty(this.pos.gui.popup_instances))
                 this.pos.gui.show_popup("error", {
                     title: title || _t("Payment Terminal Error"),
-                    body: msg,
-                });
-        },
-
-        _show_tip: function(msg, title) {
-            if (!_.isEmpty(this.pos.gui.popup_instances))
-                this.pos.gui.show_popup("alert", {
-                    title: title || _t("Payment Terminal"),
                     body: msg,
                 });
         },

--- a/pos_payment_terminal/static/src/js/payment_terminal.js
+++ b/pos_payment_terminal/static/src/js/payment_terminal.js
@@ -23,6 +23,16 @@ odoo.define("pos_payment_terminal.payment", function(require) {
             return this._oca_payment_terminal_pay();
         },
 
+        send_payment_cancel: function() {
+            this._super.apply(this, arguments);
+            this._show_tip(
+                _t(
+                    "Cancel the transaction by pressing the red button on the payment terminal."
+                )
+            );
+            return Promise.resolve();
+        },
+
         _oca_payment_terminal_pay: function() {
             var order = this.pos.get_order();
             var pay_line = order.selected_paymentline;
@@ -169,10 +179,19 @@ odoo.define("pos_payment_terminal.payment", function(require) {
         },
 
         _show_error: function(msg, title) {
-            this.pos.gui.show_popup("error", {
-                title: title || _t("Payment Terminal Error"),
-                body: msg,
-            });
+            if (!_.isEmpty(this.pos.gui.popup_instances))
+                this.pos.gui.show_popup("error", {
+                    title: title || _t("Payment Terminal Error"),
+                    body: msg,
+                });
+        },
+
+        _show_tip: function(msg, title) {
+            if (!_.isEmpty(this.pos.gui.popup_instances))
+                this.pos.gui.show_popup("alert", {
+                    title: title || _t("Payment Terminal"),
+                    body: msg,
+                });
         },
     });
     return OCAPaymentTerminal;


### PR DESCRIPTION
Because `send_payment_cancel` was not implemented and the original Odoo version does not return a promise at all, I got the following error on payment cancel:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'finally') [point_of_sale.assets.js:268]
```

Not only does this error look funny in the Javascript console, but I also got problems with black screen when running POS in debug mode, because apparently once a payment is cancelled but it's not handled with a promise, it retries on page load, causing a Javascript error on page load.

While of course the best course of action is to implement the actual cancel flow, this was out of scope for the moment and so I just display a popup telling the user to cancel the payment with the red button - and then set the promise as resolved.