### PR TITLE
[14.0][FIX] pos_cash_move_reason: update/fix ir.rule multi-company

### DIFF
--- a/pos_cash_move_reason/security/ir_rule.xml
+++ b/pos_cash_move_reason/security/ir_rule.xml
@@ -11,6 +11,6 @@
         <field name="global" eval="True" />
         <field
             name="domain_force"
-        >['|', ('company_id', '=', user.company_id.id), ('company_id', '=', False)]</field>
+        >['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
     </record>
 </odoo>


### PR DESCRIPTION
If the user switch company (via interface, top right menu) to use another company that the main one. It's not possible to create a new move reason as the record rule raise an exception.