### PR TITLE
[14.0][FIX] pos_report_session_summary

### DIFF
--- a/pos_report_session_summary/views/session_summary_report.xml
+++ b/pos_report_session_summary/views/session_summary_report.xml
@@ -10,5 +10,7 @@
         <field
             name="report_file"
         >pos_report_session_summary.report_session_summary</field>
+        <field name="binding_model_id" ref="point_of_sale.model_pos_session" />
+        <field name="binding_type">report</field>
     </record>
 </odoo>


### PR DESCRIPTION
The print context menu is not created automatically, two fields are missing in the report definition.