### PR TITLE
[IMP] pos_event_sale: Apply discount on event tickets

### DIFF
--- a/pos_event_sale/static/src/xml/EventTicketsPopup.xml
+++ b/pos_event_sale/static/src/xml/EventTicketsPopup.xml
@@ -37,7 +37,9 @@
             <div class="product-img">
                 <img t-att-src="image_url" alt="Product image" />
                 <span class="price-tag">
-                    <t t-esc="widget.format_currency(ticket.price, 'Product Price')" />
+                    <t
+                        t-esc="widget.format_currency(ticket_final_price, 'Product Price')"
+                    />
                 </span>
                 <!-- Availability indicator -->
                 <t t-call="EventAvailabilityBadge" />


### PR DESCRIPTION
Currently when we sell event in pos, the price applied from the ticket is the one defined in the event ticket.
We need to be able to apply discounts on the top of that price. The discount should come from the pricelist that the user selected.