### PR TITLE
[13.0] [FIX] pos_margin: avoid located CI issues

### DIFF
--- a/pos_margin/tests/test_module.py
+++ b/pos_margin/tests/test_module.py
@@ -10,10 +10,30 @@ class TestModule(TransactionCase):
         super(TestModule, self).setUp()
         self.PosOrder = self.env["pos.order"]
         self.pos_product = self.env.ref("point_of_sale.whiteboard_pen")
-        self.pricelist = self.env.ref("product.list0")
-
+        self.pricelist = self.env["product.pricelist"].create(
+            {
+                "name": "Test pricelist",
+                "currency_id": self.env.user.company_id.currency_id.id,
+                "item_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "applied_on": "3_global",
+                            "compute_price": "formula",
+                            "base": "list_price",
+                        },
+                    )
+                ],
+            }
+        )
         # Create a new pos config and open it
-        self.pos_config = self.env.ref("point_of_sale.pos_config_main").copy()
+        self.pos_config = self.env.ref("point_of_sale.pos_config_main").copy(
+            {
+                "available_pricelist_ids": [(6, 0, self.pricelist.ids)],
+                "pricelist_id": self.pricelist.id,
+            }
+        )
         self.pos_config.open_session_cb()
         self.payment_method = self.pos_config.payment_method_ids[0].id
 


### PR DESCRIPTION
Ensure test correctness when a different default localization is set on
the CI as the existing pricelist could be in a different currency and
that will cause all kind of test failures.

cc @Tecnativa TT32039

Cherry pick of https://github.com/OCA/pos/commit/c672b53bf89519957e9465f4f8c2c3a91a6da0ca

ping @chienandalu @pedrobaeza 