### PR TITLE
[FIX] pos_customer_display and pos_payment_terminal :  disable use_proxy on demo data

### DIFF
--- a/pos_customer_display/__manifest__.py
+++ b/pos_customer_display/__manifest__.py
@@ -14,6 +14,5 @@
         "views/assets.xml",
         "views/view_pos_config.xml",
     ],
-    "demo": ["demo/pos_config.xml"],
     "installable": True,
 }

--- a/pos_customer_display/demo/pos_config.xml
+++ b/pos_customer_display/demo/pos_config.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<odoo noupdate="1">
-
-    <record id="point_of_sale.pos_config_main" model="pos.config">
-        <field name="iface_customer_display" eval="True"/>
-    </record>
-
-</odoo>

--- a/pos_payment_terminal/__manifest__.py
+++ b/pos_payment_terminal/__manifest__.py
@@ -16,7 +16,6 @@
         'views/account_journal.xml',
         'views/assets.xml',
         ],
-    'demo': ['demo/pos_config.xml'],
     'qweb': ['static/src/xml/pos_payment_terminal.xml'],
     'installable': True,
 }

--- a/pos_payment_terminal/demo/pos_config.xml
+++ b/pos_payment_terminal/demo/pos_config.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo>
-
-    <record id="point_of_sale.pos_config_main" model="pos.config">
-        <field name="iface_payment_terminal" eval="True"/>
-    </record>
-
-</odoo>


### PR DESCRIPTION
remove default value that enable use_proxy and make other tests failing

CC : @eLBati 

Fixes : test in : https://github.com/OCA/pos/pull/762


**Note**
- generally, it's great that new features are enabled by default on demo data. it makes the module "ready to test" on runbot / runboat / or locally.
- however, enabling iface (proxy) features enable ``use_proxy``, so it is changing the behaviour of the point of sale, and make the JS tests of the point of sale not predictive.
