### PR TITLE
[FIX] use python 3.7 instead 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
     - $HOME/.cache/pip
 
 python:
-  - "3.5"
+  - "3.7"
 
 addons:
   postgresql: "9.6"


### PR DESCRIPTION
A new module fetchmail_outlook has been added with auto_install=True using
f-string which start from python 3.6. As long python3.5 and 3.6 are not
suppoted by python, move to the oldest python version supported