### PR TITLE
[FIX] pos_cash_move_reason

### DIFF
--- a/pos_cash_move_reason/wizard/wizard_pos_move_reason.py
+++ b/pos_cash_move_reason/wizard/wizard_pos_move_reason.py
@@ -104,7 +104,6 @@ class WizardPosMoveReason(models.TransientModel):
             "statement_id": self.statement_id.id,
             "journal_id": self.journal_id.id,
             "amount": amount,
-            "name": self.name,
-            "payment_ref": self.session_id.name,
+            "payment_ref": f"{self.session_id.name} - {self.name}",
             "counterpart_account_id": account_id,
         }


### PR DESCRIPTION
- Changed the field where the reason for the withdrawal or receipt of money is indicated, if left in the field name, it changes the name of the accounting entry and gives an error.