### PR TITLE
[FIX] #777 pos_customer_required_fields

### DIFF
--- a/pos_customer_required_fields/static/src/js/screens.js
+++ b/pos_customer_required_fields/static/src/js/screens.js
@@ -3,7 +3,7 @@
     @author Pierre Verkest <pierreverkest84@gmail.com>
     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
  */
-odoo.define('pos_order_zipcode.screens', function (require) {
+odoo.define('pos_customers_required_fields.screens', function (require) {
     "use strict";
 
     var screens = require('point_of_sale.screens');
@@ -11,7 +11,7 @@ odoo.define('pos_order_zipcode.screens', function (require) {
     screens.PaymentScreenWidget.include({
         missing_customer_fields: function(){
             const customer = this.pos.get_order().get_client();
-            if(!customer){
+            if(!customer || this.pos.config.res_partner_required_fields_names === ""){
                 // In case customer is not required there are no missing fields
                 // there are some other check that ensure if customer is
                 // required or not, it's not the intent of this method to decide


### PR DESCRIPTION
fix #777

In case there is no required field we don't want to
lock user on payment screen.

As required fields list is stored in string variable
spliting an empty string return an array of one empty
string which would return one missing field which
is locking users