### PR TITLE
[14.0][IMP][WIP] Allow refund in pos_payment_terminal

### DIFF
--- a/pos_payment_terminal/__manifest__.py
+++ b/pos_payment_terminal/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "POS Payment Terminal",
-    "version": "14.0.2.0.0",
+    "version": "14.0.3.0.0",
     "category": "Point Of Sale",
     "summary": "Point of sale: support generic payment terminal",
     "author": (

--- a/pos_payment_terminal/static/src/js/payment_terminal.js
+++ b/pos_payment_terminal/static/src/js/payment_terminal.js
@@ -28,7 +28,7 @@ odoo.define("pos_payment_terminal.payment", function (require) {
             var order = this.pos.get_order();
             var pay_line = order.selected_paymentline;
             var currency = this.pos.currency;
-            if (pay_line.amount == 0) {
+            if (pay_line.amount === 0) {
                 this._show_error(
                     _t("Cannot process transactions with zero amount.")
                 );

--- a/pos_payment_terminal/static/src/js/payment_terminal.js
+++ b/pos_payment_terminal/static/src/js/payment_terminal.js
@@ -28,20 +28,20 @@ odoo.define("pos_payment_terminal.payment", function (require) {
             var order = this.pos.get_order();
             var pay_line = order.selected_paymentline;
             var currency = this.pos.currency;
-            if (pay_line.amount <= 0) {
-                // TODO check if it's possible or not
+            if (pay_line.amount == 0) {
                 this._show_error(
-                    _t("Cannot process transactions with zero or negative amount.")
+                    _t("Cannot process transactions with zero amount.")
                 );
                 return Promise.resolve();
             }
             var data = {
-                amount: pay_line.amount,
+                amount: Math.abs(pay_line.amount),
                 currency_iso: currency.name,
                 currency_decimals: currency.decimals,
                 payment_mode: this.payment_method.oca_payment_terminal_mode,
                 payment_id: pay_line.cid,
                 order_id: order.name,
+                refund: pay_line.amount < 0,
             };
             if (this.payment_method.oca_payment_terminal_id) {
                 data.terminal_id = this.payment_method.oca_payment_terminal_id;

--- a/pos_payment_terminal/static/src/js/payment_terminal.js
+++ b/pos_payment_terminal/static/src/js/payment_terminal.js
@@ -29,9 +29,7 @@ odoo.define("pos_payment_terminal.payment", function (require) {
             var pay_line = order.selected_paymentline;
             var currency = this.pos.currency;
             if (pay_line.amount === 0) {
-                this._show_error(
-                    _t("Cannot process transactions with zero amount.")
-                );
+                this._show_error(_t("Cannot process transactions with zero amount."));
                 return Promise.resolve();
             }
             var data = {


### PR DESCRIPTION
Depending on the terminal a refund may be required or possible to implement. This is why we would propose to send the amount and a refund flag to the driver to let him handle it.

This requires the pywebdriver to be updated first hence we would repin the major module version.

This patch is bundled together with [pywebdriver PR 95](https://github.com/akretion/pywebdriver/pull/95)