### PR TITLE
[FIX] pos_access_right : remove bad css that impact all PoS

### DIFF
--- a/pos_access_right/static/src/css/pos.css
+++ b/pos_access_right/static/src/css/pos.css
@@ -5,12 +5,6 @@
     cursor: not-allowed;
 }
 
-.pos .ticket-screen .order-row:hover {
-    background: rgb(230, 230, 230);
-    color: white;
-    cursor: not-allowed;
-}
-
 .pos .ticket-screen .controls button.highlight.disabled-mode:hover {
     background: #c7c7c7;
     border: solid 1px rgb(220, 220, 220);
@@ -20,9 +14,4 @@
 
 .pos .ticket-screen .pointer.disabled-mode:hover {
     cursor: not-allowed;
-}
-
-.col.center.very-narrow.delete-button {
-    cursor: not-allowed;
-    color: #a5a1a1;
 }


### PR DESCRIPTION
Hi. 

The current module  ``pos_access_right`` introduce CSS that are breaking the POS.

Step to reproduce : 
- on runboat / 14.0 (https://runboat.odoo-community.org/webui/builds.html?repo=OCA/pos&target_branch=14.0)
- Go to Point of Sale
- Click on "Orders"
- set the cursor hover the row
- the cursor is bad displayed + and the color of the row is bad.

![Capture d’écran du 2022-06-30 11-05-05](https://user-images.githubusercontent.com/3407482/176638236-e9a17dbc-eb8b-4d58-b7b6-fdc5e69ec95a.png)

Problem introduced here : https://github.com/OCA/pos/pull/630

CC : @author : @hkapatel-initos
CC : reviewer : @brendapaniagua, @flotho, @ivantodorovich
