### PR TITLE
[14.0][FIX] pos_product_template, check variant product_template_attribute_value_ids exists

### DIFF
--- a/pos_product_template/readme/CONTRIBUTORS.rst
+++ b/pos_product_template/readme/CONTRIBUTORS.rst
@@ -1,0 +1,16 @@
+* Sylvain LE GAL (https://twitter.com/legalsylvain)
+* Navarromiguel (https://github.com/navarromiguel)
+* Damendieta (https://github.com/damendieta)
+* Raphaël Reverdy (https://akretion.com)
+* Pedro Guirao (https://ingenieriacloud.com)
+
+* `Ooops <https://www.ooops404.com>`_:
+
+   * Giovanni Serra <giovanni@gslab.it>
+
+Funders
+-------
+
+The development of this module has been financially supported by:
+
+* Akretion

--- a/pos_product_template/readme/DESCRIPTION.rst
+++ b/pos_product_template/readme/DESCRIPTION.rst
@@ -1,0 +1,11 @@
+    * In Point Of Sale Front End - Products list:
+        * Display only one product per template;
+        * Display template name instead of product name;
+        * Display products quantity instead of price;
+        * Click on template displays an extra screen to select Variant;
+
+    * In Point Of Sale Front End - Variants list:
+        * Display all the products of the selected variant;
+        * Click on a attribute value filters products;
+        * Click on a product adds it to the current Order or display normal
+          extra screen if it is a weightable product;

--- a/pos_product_template/readme/ROADMAP.rst
+++ b/pos_product_template/readme/ROADMAP.rst
@@ -1,0 +1,1 @@
+* Templates with lot of variants are not shown. See https://github.com/OCA/pos/pull/135

--- a/pos_product_template/readme/USAGE.rst
+++ b/pos_product_template/readme/USAGE.rst
@@ -1,0 +1,2 @@
+Open the Point of Sale, search an article with variants.
+You will see one article instead of all the variants.

--- a/pos_product_template/static/src/js/models.js
+++ b/pos_product_template/static/src/js/models.js
@@ -141,7 +141,10 @@ odoo.define("pos_product_template.models", function (require) {
                 var tmpl_attribute_value_ids = new Set();
                 template.product_variant_ids.forEach((variant_id) => {
                     var variant = this.get_product_by_id(variant_id);
-                    if (variant != undefined) {
+                    if (
+                        variant !== undefined &&
+                        variant.product_template_attribute_value_ids
+                    ) {
                         variant.product_template_attribute_value_ids.forEach(
                             (tmpl_attr_value_id) => {
                                 tmpl_attribute_value_ids.add(


### PR DESCRIPTION
Better check for `variant.product_template_attribute_value_ids` it must exists in order to loop.