### PR TITLE
[FIX][DOC] pos_edit_order_line : correct reference to description image

### DIFF
--- a/pos_edit_order_line/readme/DESCRIPTION.rst
+++ b/pos_edit_order_line/readme/DESCRIPTION.rst
@@ -2,5 +2,5 @@ This module adds a button "Edit order lines" in main POS interface to allow an e
 
 On button click, a popup with order lines allows user to input a clear value for each field, instead of having to use the default process of selecting which field to edit, which is not very intuitive and error-prone.
 
-.. image:: https://raw.githubusercontent.com/pos_edit_order_line/static/description/pos_edit_order_line.png
+.. image:: ../static/description/pos_edit_order_line.png
   :alt: Display Edit Order Line Popup


### PR DESCRIPTION
fix : https://github.com/OCA/pos/pull/796#issuecomment-1197916762

FYI : @GabbasovDinar; @francesco-ooops

here is the correct way to reference images in the readme files.