### PR TITLE
[14.0][FIX][pos_margin] Hide margin in Front End if config is false

### DIFF
--- a/pos_margin/static/src/xml/pos_margin.xml
+++ b/pos_margin/static/src/xml/pos_margin.xml
@@ -9,12 +9,14 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
     <t t-name="OrderSummaryMargin" owl="1">
         <div class="summary clearfix">
-            <div class="line">
-                <div class="subentry order-margin">
-                    <span>Margin: </span><span class="value-margin">0.00 €</span>
-                    (<span class="value-margin-rate">0.00 %</span>)
+            <t t-if="env.pos.config.iface_display_margin">
+                <div class="line">
+                    <div class="subentry order-margin">
+                        <span>Margin: </span><span class="value-margin">0.00 €</span>
+                        (<span class="value-margin-rate">0.00 %</span>)
+                    </div>
                 </div>
-            </div>
+            </t>
         </div>
     </t>
 


### PR DESCRIPTION
Before this fix, Margin is displayed on the frontend on the sale order screen even if the option is not selected in config