### PR TITLE
[14.0][FIX] pos_payment_terminal - Prevent endless polling

### DIFF
--- a/pos_access_right/static/src/js/models.js
+++ b/pos_access_right/static/src/js/models.js
@@ -7,12 +7,12 @@ odoo.define("pos_access_right.models", function (require) {
     models.PosModel = models.PosModel.extend({
         get_cashier: function () {
             const pos_cashier = posmodel_super.get_cashier.apply(this);
+            let cashier = null;
             try {
-                const cashier = this.env.pos.users.find(
+                cashier = this.env.pos.users.find(
                     (user) => user.id === pos_cashier.user_id[0]
                 );
-            }
-            catch (err) {
+            } catch {
                 return pos_cashier;
             }
             pos_cashier.hasGroupPayment =

--- a/pos_access_right/static/src/js/models.js
+++ b/pos_access_right/static/src/js/models.js
@@ -7,9 +7,14 @@ odoo.define("pos_access_right.models", function (require) {
     models.PosModel = models.PosModel.extend({
         get_cashier: function () {
             const pos_cashier = posmodel_super.get_cashier.apply(this);
-            const cashier = this.env.pos.users.find(
-                (user) => user.id === pos_cashier.user_id[0]
-            );
+            try {
+                const cashier = this.env.pos.users.find(
+                    (user) => user.id === pos_cashier.user_id[0]
+                );
+            }
+            catch (err) {
+                return pos_cashier;
+            }
             pos_cashier.hasGroupPayment =
                 cashier &&
                 cashier.groups_id.includes(this.env.pos.config.group_payment_id[0]);

--- a/pos_payment_terminal/static/src/js/payment_terminal.js
+++ b/pos_payment_terminal/static/src/js/payment_terminal.js
@@ -171,7 +171,9 @@ odoo.define("pos_payment_terminal.payment", function (require) {
                         }
                     })
                     .catch(() => {
-                        console.error("Error querying terminal driver status");
+                        let err_func = console.error;
+                        if (self.pos.test_no_console_error) err_func = console.log;
+                        err_func("Error querying terminal driver status");
                         // We could not query the transaction status so we
                         // won't know the transaction result: we let the user
                         // enter the outcome manually. This is done by

--- a/pos_payment_terminal/static/tests/pos_payment_terminal_tests.js
+++ b/pos_payment_terminal/static/tests/pos_payment_terminal_tests.js
@@ -1,0 +1,287 @@
+odoo.define("pos_payment_terminal.pos_payment_terminal_tests", function (require) {
+    "use strict";
+
+    /* global QUnit */
+
+    var OCAPaymentTerminal = require("pos_payment_terminal.payment");
+
+    require("web.test_utils");
+    const Session = require("web.Session");
+    const makePosTestEnv = require("point_of_sale.test_env");
+
+    const promiseTimeout = function (ms, promise) {
+        // Create a promise that rejects in <ms> milliseconds
+        const timeout = new Promise((resolve, reject) => {
+            const id = setTimeout(() => {
+                clearTimeout(id);
+                reject("Timed out in " + ms + "ms.");
+            }, ms);
+        });
+
+        // Returns a race between our timeout and the passed in promise
+        return Promise.race([promise, timeout]);
+    };
+
+    const pinPM = {
+        id: 0,
+        name: "PIN",
+        is_cash_count: false,
+        use_payment_terminal: true,
+    };
+
+    QUnit.module(
+        "pos_payment_terminal",
+        {
+            beforeEach: function (assert) {
+                assert.expect(6);
+
+                // Create POS test environment
+                const env = makePosTestEnv();
+                assert.ok(env);
+                assert.ok(env.pos);
+                env.pos.proxy.connection = new Session(undefined, "", {use_cors: true});
+                env.pos.proxy.set_connection_status("connected");
+
+                // Create OCA payment terminal object
+                const payment_terminal = new OCAPaymentTerminal(env.pos, pinPM);
+                assert.ok(payment_terminal);
+                assert.ok(payment_terminal.pos);
+                payment_terminal._show_error = function (msg) {
+                    console.log("Would have shown error: ", msg);
+                };
+
+                // Get current order
+                const order = env.pos.get_order();
+                assert.ok(order);
+
+                // Add some orderlines to create a nonzero amount
+                const chair1 = env.pos.db.search_product_in_category(
+                    0,
+                    "Office Chair"
+                )[0];
+                order.add_product(chair1);
+
+                // Add payment line and select it
+                const paymentline1 = order.add_paymentline(pinPM);
+                assert.ok(order.paymentlines.length === 1);
+                order.select_paymentline(paymentline1);
+
+                // Share variables with the tests.
+                this.env = env;
+                this.order = order;
+                this.payment_terminal = payment_terminal;
+                this.paymentline1 = paymentline1;
+            },
+
+            afterEach: function () {
+                // NOTE: if this fails to get called, the only way to repair the tests
+                // is to go in Chrome inspection tools, Application, Local Storage and deleting openerp_*_unpaid*
+                this.order.remove_paymentline(this.paymentline1);
+                this.env.pos.delete_current_order();
+            },
+        },
+        function () {
+            QUnit.test("Happy flow - Successful PIN transaction", async function (
+                assert
+            ) {
+                assert.expect(7);
+                var self = this;
+
+                self.env.pos.proxy.connection.rpc = async function (
+                    url,
+                    params,
+                    options
+                ) {
+                    console.log("MOCK CALL TO", url, params, options);
+                    // We get back a transaction ID, that we can then poll for
+                    if (url === "/hw_proxy/payment_terminal_transaction_start") {
+                        return new Promise((resolve) => {
+                            resolve({transaction_id: "X1234"});
+                        });
+                    } else if (url.startsWith("/hw_proxy/status_json")) {
+                        return new Promise(async (resolve) => {
+                            resolve({
+                                test_driver: {
+                                    is_terminal: true,
+                                    transactions: [
+                                        {
+                                            transaction_id: "X1234",
+                                            success: true,
+                                            status: "SUCCESS",
+                                            status_details: "Pretty successful",
+                                        },
+                                    ],
+                                },
+                            });
+                        });
+                    }
+                    console.log("Unexpected call, ignoring");
+                };
+                var done = assert.async();
+                self.payment_terminal.send_payment_request().then(function () {
+                    assert.ok(self.paymentline1.terminal_transaction_success);
+                    done();
+                });
+            });
+
+            QUnit.test("Sad flow 1 - Failure reported by PIN machine", async function (
+                assert
+            ) {
+                assert.expect(7);
+                var self = this;
+
+                self.env.pos.test_no_console_error = true;
+                self.env.pos.proxy.connection.rpc = async function (
+                    url,
+                    params,
+                    options
+                ) {
+                    console.log("MOCK CALL TO", url, params, options);
+                    if (url === "/hw_proxy/payment_terminal_transaction_start") {
+                        return new Promise((resolve) => {
+                            resolve({transaction_id: "X1234"});
+                        });
+                    } else if (url.startsWith("/hw_proxy/status_json")) {
+                        return new Promise(async (resolve) => {
+                            resolve({
+                                test_driver: {
+                                    is_terminal: true,
+                                    transactions: [
+                                        {
+                                            transaction_id: "X1234",
+                                            success: false,
+                                            status: "FAILURE",
+                                            status_details: "Pretty unsuccessful",
+                                        },
+                                    ],
+                                },
+                            });
+                        });
+                    }
+                    console.log("Unexpected call, ignoring");
+                };
+                var done = assert.async();
+                self.payment_terminal.send_payment_request().then(function () {
+                    assert.notOk(self.paymentline1.terminal_transaction_success);
+                    done();
+                });
+            });
+
+            QUnit.test("Sad flow 2 - Cancellation by user", async function (assert) {
+                assert.expect(7);
+                var self = this;
+
+                self.env.pos.test_no_console_error = true;
+                self.env.pos.proxy.connection.rpc = async function (
+                    url,
+                    params,
+                    options
+                ) {
+                    console.log("MOCK CALL TO", url, params, options);
+                    if (url === "/hw_proxy/payment_terminal_transaction_start") {
+                        return new Promise((resolve) => {
+                            resolve({transaction_id: "X1234"});
+                        });
+                    } else if (url.startsWith("/hw_proxy/status_json")) {
+                        // Simulate what the user 'Cancel' button does
+                        this.payment_terminal.send_payment_cancel(
+                            this.order,
+                            this.paymentline1.cid
+                        );
+                        // Meanwhile return an undefined result for the transaction, to keep polling
+                        return new Promise((resolve) => {
+                            resolve({
+                                test_driver: {
+                                    is_terminal: true,
+                                    transactions: [],
+                                },
+                            });
+                        });
+                    }
+                    console.log("Unexpected call, ignoring");
+                };
+                await assert.rejects(this.payment_terminal.send_payment_request());
+            });
+
+            QUnit.test("Sad flow 3 - Timeout in POSbox response", async function (
+                assert
+            ) {
+                assert.expect(7);
+                var self = this;
+
+                self.env.pos.test_no_console_error = true;
+                self.env.pos.proxy.connection.rpc = async function (
+                    url,
+                    params,
+                    options
+                ) {
+                    console.log("MOCK CALL TO", url, params, options);
+                    // We get back a transaction ID, that we can then poll for
+                    if (url === "/hw_proxy/payment_terminal_transaction_start") {
+                        return new Promise((resolve) => {
+                            resolve({transaction_id: "X1234"});
+                        });
+                    } else if (url.startsWith("/hw_proxy/status_json")) {
+                        return promiseTimeout(
+                            options.timeout,
+                            new Promise(async (resolve) => {
+                                // Too long! > 1000 ms
+                                await new Promise((r) => setTimeout(r, 10000));
+                                resolve({
+                                    test_driver: {
+                                        is_terminal: true,
+                                        transactions: [
+                                            {
+                                                transaction_id: "X1234",
+                                                success: true,
+                                                status: "SUCCESS",
+                                                status_details: "Pretty successful",
+                                            },
+                                        ],
+                                    },
+                                });
+                            })
+                        );
+                    }
+                    console.log("Unexpected call, ignoring");
+                };
+                assert.rejects(self.payment_terminal.send_payment_request());
+            });
+
+            QUnit.test(
+                "Sad flow 4 - global timeout - transaction result never comes",
+                async function (assert) {
+                    assert.expect(7);
+                    var self = this;
+                    self.payment_terminal.global_timeout = 5;
+                    self.env.pos.test_no_console_error = true;
+                    self.env.pos.proxy.connection.rpc = async function (
+                        url,
+                        params,
+                        options
+                    ) {
+                        console.log("MOCK CALL TO", url, params, options);
+                        // We get back a transaction ID, that we can then poll for
+                        if (url === "/hw_proxy/payment_terminal_transaction_start") {
+                            return new Promise((resolve) => {
+                                resolve({transaction_id: "X1234"});
+                            });
+                        } else if (url.startsWith("/hw_proxy/status_json")) {
+                            return new Promise(async (resolve) => {
+                                await new Promise((r) => setTimeout(r, 800));
+                                resolve({
+                                    test_driver: {
+                                        is_terminal: true,
+                                        transactions: [],
+                                    },
+                                });
+                            });
+                        }
+                        console.log("Unexpected call, ignoring");
+                    };
+                    assert.rejects(self.payment_terminal.send_payment_request());
+                }
+            );
+        }
+    );
+});

--- a/pos_payment_terminal/tests/__init__.py
+++ b/pos_payment_terminal/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_js

--- a/pos_payment_terminal/tests/test_js.py
+++ b/pos_payment_terminal/tests/test_js.py
@@ -1,0 +1,19 @@
+import odoo.tests
+
+
+@odoo.tests.tagged("post_install", "-at_install")
+class WebSuite(odoo.tests.HttpCase):
+    def setUp(self):
+        super().setUp()
+        env = self.env(user=self.env.ref("base.user_admin"))
+        self.main_pos_config = env.ref("point_of_sale.pos_config_main")
+
+    def test_js(self):
+        self.main_pos_config.open_session_cb(check_coa=False)
+        self.browser_js(
+            "/pos/ui/tests?mod=pos_payment_terminal&failfast",
+            "",
+            "",
+            login="admin",
+            timeout=1800,
+        )

--- a/pos_payment_terminal/views/assets.xml
+++ b/pos_payment_terminal/views/assets.xml
@@ -14,4 +14,17 @@
       </xpath>
     </template>
 
+    <template
+        id="qunit_suite"
+        name="pos_payment_terminal tests"
+        inherit_id="point_of_sale.qunit_suite_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/pos_payment_terminal/static/tests/pos_payment_terminal_tests.js"
+            />
+        </xpath>
+    </template>
+
 </odoo>


### PR DESCRIPTION
If a transaction is cancelled user-side, or the driver installed on the POSbox never returns the status for the transaction, the current `pos_payment_terminal` module keeps throwing out `status_json` calls until forever. Over a long time, this can result in many parallel threads calling `status_json`, draining resources of the POS browser and of the POSbox.

This PR:

- Introduces a hard timeout of 5 minutes after which polling is stopped no matter what
- Stops polling whenever "cancel" or "done" is reached either by user or from the device
- Makes it easier in browser debug tools to distinguish `status_json` calls from `pos_payment_terminal`, from the normal ones
- Deals more robustly with what hardware drivers return, eg when transaction status is undefined 
- Adds tests for common flows (these helped me a lot in debugging these issues)