### PR TITLE
[15.0] [FIX+IMP] `pos_lot_selection`

### DIFF
--- a/pos_lot_selection/models/stock_production_lot.py
+++ b/pos_lot_selection/models/stock_production_lot.py
@@ -10,7 +10,7 @@ class ProductionLot(models.Model):
 
     @api.model
     def get_available_lots_for_pos(self, product_id, company_id):
-        lots = self.search(
+        lots = self.sudo().search(
             [
                 "&",
                 ["product_id", "=", product_id],

--- a/pos_lot_selection/static/src/js/EditListPopup.js
+++ b/pos_lot_selection/static/src/js/EditListPopup.js
@@ -2,7 +2,7 @@
     Copyright 2022 Camptocamp SA
     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 */
-odoo.define("pos_lot_barcode.EditListPopup", function (require) {
+odoo.define("pos_lot_selection.EditListPopup", function (require) {
     "use strict";
 
     const EditListPopup = require("point_of_sale.EditListPopup");

--- a/pos_lot_selection/static/src/js/EditListPopup.js
+++ b/pos_lot_selection/static/src/js/EditListPopup.js
@@ -17,6 +17,7 @@ odoo.define("pos_lot_selection.EditListPopup", function (require) {
                 }
             }
         };
+
     Registries.Component.extend(EditListPopup, LotSelectEditListPopup);
     return EditListPopup;
 });

--- a/pos_lot_selection/static/src/js/OrderWidget.js
+++ b/pos_lot_selection/static/src/js/OrderWidget.js
@@ -1,19 +1,26 @@
+/*
+    Copyright 2022 Camptocamp SA
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+*/
 odoo.define("pos_lot_selection.CustomOrderWidget", function (require) {
     "use strict";
 
     const Registries = require("point_of_sale.Registries");
     const OrderWidget = require("point_of_sale.OrderWidget");
 
-    var CustomOrderWidget = (OrderWidget) =>
+    const CustomOrderWidget = (OrderWidget) =>
         class extends OrderWidget {
+            /**
+             * @override
+             */
             async _editPackLotLines(event) {
-                var self = this;
                 const orderline = event.detail.orderline;
-                this.env.session.lots = await this.env.pos.get_lots(orderline.product);
-                return super._editPackLotLines(event).then(function (result) {
-                    self.env.session.lots = [];
-                    return result;
-                });
+                this.env.session.lots = await this.env.pos.getProductLots(
+                    orderline.product
+                );
+                const res = await super._editPackLotLines(...arguments);
+                this.env.session.lots = undefined;
+                return res;
             }
         };
 

--- a/pos_lot_selection/static/src/js/ProductScreen.js
+++ b/pos_lot_selection/static/src/js/ProductScreen.js
@@ -10,19 +10,16 @@ odoo.define("pos_lot_selection.ProductScreen", function (require) {
 
     const PosLotSaleProductScreen = (ProductScreen) =>
         class extends ProductScreen {
-            async _getAddProductOptions(product, base_code) {
-                var self = this;
+            /**
+             * @override
+             */
+            async _getAddProductOptions(product) {
                 if (["serial", "lot"].includes(product.tracking)) {
-                    // Set lots to context as it one possible way to extract arguments
-                    // later in popup
-                    this.env.session.lots = await this.env.pos.get_lots(product);
+                    this.env.session.lots = await this.env.pos.getProductLots(product);
                 }
-                return super
-                    ._getAddProductOptions(product, (base_code = base_code))
-                    .then(function (result) {
-                        self.env.session.lots = [];
-                        return result;
-                    });
+                const res = await super._getAddProductOptions(...arguments);
+                this.env.session.lots = undefined;
+                return res;
             }
         };
 

--- a/pos_lot_selection/static/src/js/models.js
+++ b/pos_lot_selection/static/src/js/models.js
@@ -8,22 +8,25 @@ odoo.define("pos_lot_selection.models", function (require) {
     const models = require("point_of_sale.models");
 
     models.PosModel = models.PosModel.extend({
-        async get_lots(product) {
-            var lots = await this.rpc(
-                {
-                    model: "stock.production.lot",
-                    method: "get_available_lots_for_pos",
-                    kwargs: {
-                        product_id: product.id,
-                        company_id: this.env.session.company_id,
+        async getProductLots(product) {
+            try {
+                return await this.rpc(
+                    {
+                        model: "stock.production.lot",
+                        method: "get_available_lots_for_pos",
+                        kwargs: {
+                            product_id: product.id,
+                            company_id: this.env.session.company_id,
+                        },
                     },
-                },
-                {shadow: true}
-            ).catch(() => Promise.resolve([false]));
-            if (!lots) {
-                lots = [];
+                    {shadow: true}
+                );
+            } catch (error) {
+                console.error(error);
+                return [];
             }
-            return lots;
         },
     });
+
+    return models;
 });

--- a/pos_lot_selection/static/src/xml/LotSelectorPopup.xml
+++ b/pos_lot_selection/static/src/xml/LotSelectorPopup.xml
@@ -4,26 +4,15 @@
 <templates id="template" xml:space="preserve">
 
     <t t-inherit="point_of_sale.EditListPopup" t-inherit-mode="extension">
-
-        <xpath expr="//t[@t-foreach='state.array']" position="replace">
-            <t t-foreach="state.array" t-as="item" t-key="item._id">
-                <t t-if="props.lots">
-                    <EditListInput item="item" lots="props.lots" />
-                </t>
-                <t t-else="">
-                    <EditListInput item="item" />
-                </t>
-            </t>
-        </xpath>
+        <EditListInput position="attributes">
+            <attribute name="lots">props.lots</attribute>
+        </EditListInput>
     </t>
 
-
     <t t-inherit="point_of_sale.EditListInput" t-inherit-mode="extension">
-
         <xpath expr="//input" position="attributes">
             <attribute name="list">prepared_lots</attribute>
         </xpath>
-
         <xpath expr="//input" position="after">
             <datalist id="prepared_lots">
                 <t t-if="props.lots">


### PR DESCRIPTION
This PR achieves the following things, each on a separate commit:

1. Use the proper module name in the js definition. This made the module incompatible with `pos_lot_barcode` because of the overlapping js definitions.
2. Fix an issue where this module doesn't work for Point of Sale users with minimal access rights.
3. Modernize js code
4. Simplify view definitions, mainly to avoid the `replace` operation that reduces modules compatibility


---

C2C ref: BSATE-58