### PR TITLE
[15.0] [FIX] `pos_event_sale`: `event_barcode` compatibility (enterprise)

### DIFF
--- a/pos_event_sale/static/src/xml/ReceiptScreen/EventRegistrationReceipt.xml
+++ b/pos_event_sale/static/src/xml/ReceiptScreen/EventRegistrationReceipt.xml
@@ -59,7 +59,7 @@
                     <div t-if="registration.barcode">
                         <img
                             class="barcode"
-                            t-attf-src="/report/barcode/?type=Code128&amp;value=#{registration.barcode}&amp;width=300&amp;height=75&amp;humanreadable=1"
+                            t-attf-src="/report/barcode/?type=Code128&amp;value={{registration.barcode}}&amp;width=300&amp;height=75&amp;humanreadable=1"
                             alt="Barcode"
                         />
                     </div>


### PR DESCRIPTION
There was a typo on the xml view, having it not rendering properly.