### PR TITLE
[14.0][IMP] `pos_product_template`: Sort product attribute

### DIFF
--- a/pos_product_template/static/src/js/SelectVariantPopup.js
+++ b/pos_product_template/static/src/js/SelectVariantPopup.js
@@ -59,9 +59,18 @@ odoo.define("pos_product_template.SelectVariantPopup", function (require) {
             useListener("click-product", this._clickProduct);
             useListener("click-attribute-value", this._clickAttributeValue);
 
+            attributes.forEach((attribute) => {
+                const productAttribute = this.env.pos.db.product_attribute_by_id[
+                    attribute.id
+                ];
+                attribute.sequence = productAttribute.sequence;
+            });
+
             this.state.ptav = ptav;
             this.state.ptav_unavailable_ids = [];
-            this.state.attributes = attributes;
+            this.state.attributes = attributes.sort((a, b) =>
+                a.sequence > b.sequence ? 1 : b.sequence > a.sequence ? -1 : 0
+            );
             this.state.products = products;
         }
 

--- a/pos_product_template/static/src/js/models.js
+++ b/pos_product_template/static/src/js/models.js
@@ -58,7 +58,7 @@ odoo.define("pos_product_template.models", function (require) {
         },
         {
             model: "product.attribute",
-            fields: ["name", "value_ids"],
+            fields: ["name", "value_ids", "sequence"],
             loaded: function (self, attributes) {
                 self.db.add_product_attributes(attributes);
             },


### PR DESCRIPTION
This improvement allows the product attributes - in the PopUp that is opened in the POS - to be organized by sequence and not by the registration ID in the system.