### PR TITLE
[IMP] pos_invoicing : confirm invoices that are created in the back-office by the UI, to avoid user to change / delete invoices created and paid from PoS

### DIFF
--- a/pos_invoicing/models/pos_order.py
+++ b/pos_invoicing/models/pos_order.py
@@ -3,7 +3,8 @@
 # @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models
+from odoo import _, api, models
+from odoo.exceptions import UserError
 
 
 class PosOrder(models.Model):
@@ -14,4 +15,53 @@ class PosOrder(models.Model):
         res.update({
             'pos_pending_payment': True,
         })
+        return res
+
+    @api.model
+    def create_from_ui(self, orders):
+        return super(
+            PosOrder, self.with_context(pos_order_invoiced=True)
+        ).create_from_ui(orders)
+
+    @api.multi
+    def action_pos_order_invoice(self):
+        # this function is called by the create_from_ui
+        # function, and in that case, invoice is then confirmed
+        # but if called directly (by UI, in the back-office)
+        # the confirmation is not done.
+        # So we confirm the invoice in that case.
+        res = super().action_pos_order_invoice()
+        if not self.env.context.get("pos_order_invoiced", False):
+            for order in self:
+                order.invoice_id.sudo().with_context(
+                    force_company=self.env.user.company_id.id,
+                    pos_picking_id=order.picking_id,
+                ).action_invoice_open()
+                # Check if total amount are the same
+                if (
+                    order.invoice_id.amount_total_signed != order.amount_total
+                ):
+                    raise UserError(_(
+                        "Unable to create an invoice from the order"
+                        " %s because the amount totals are not the same."
+                        " %s != %s"
+                    ) % (
+                        order.name,
+                        order.invoice_id.amount_total_signed,
+                        order.amount_total,
+                    ))
+                if (
+                    order.invoice_id.amount_tax_signed != order.amount_tax
+                ):
+                    raise UserError(_(
+                        "Unable to create an invoice from the order"
+                        " %s because the amount taxes are not the same."
+                        " %s != %s"
+                    ) % (
+                        order.name,
+                        order.invoice_id.amount_tax_signed,
+                        order.amount_tax,
+                    ))
+
+                order.account_move = order.invoice_id.move_id
         return res

--- a/pos_invoicing/models/pos_order.py
+++ b/pos_invoicing/models/pos_order.py
@@ -5,6 +5,7 @@
 
 from odoo import _, api, models
 from odoo.exceptions import UserError
+from odoo.tools import float_compare
 
 
 class PosOrder(models.Model):
@@ -38,8 +39,11 @@ class PosOrder(models.Model):
                     pos_picking_id=order.picking_id,
                 ).action_invoice_open()
                 # Check if total amount are the same
-                if (
-                    order.invoice_id.amount_total_signed != order.amount_total
+                prec = order.invoice_id.currency_id.rounding
+                if float_compare(
+                    order.invoice_id.amount_total_signed,
+                    order.amount_total,
+                    precision_digits=prec
                 ):
                     raise UserError(_(
                         "Unable to create an invoice from the order"
@@ -50,8 +54,10 @@ class PosOrder(models.Model):
                         order.invoice_id.amount_total_signed,
                         order.amount_total,
                     ))
-                if (
-                    order.invoice_id.amount_tax_signed != order.amount_tax
+                if float_compare(
+                    order.invoice_id.amount_tax_signed,
+                    order.amount_tax,
+                    precision_digits=prec
                 ):
                     raise UserError(_(
                         "Unable to create an invoice from the order"

--- a/pos_order_return/models/pos_order.py
+++ b/pos_order_return/models/pos_order.py
@@ -60,7 +60,10 @@ class PosOrder(models.Model):
 
     def _action_pos_order_invoice(self):
         """Wrap common process"""
-        self.action_pos_order_invoice()
+        # make the module compatible with the pos_invoicing
+        super(
+            PosOrder, self.with_context(pos_order_invoiced=True)
+        ).action_pos_order_invoice()
         self.invoice_id.sudo().action_invoice_open()
         self.account_move = self.invoice_id.move_id
 


### PR DESCRIPTION
Rational : 

In point of sale there are two way to create invoices. 
1. by enabling invoicing in the UI (front office)
2. by clicking on "invoice" on a pos.order if the session is not closed. (back office)

In the first case, the invoice is open, so it is not possible to change it. (as the module disables the cancel option).
But in the second case, the invoice is in a draft state, so it is possible to change / update / delete the invoice that should not be possible.
