### PR TITLE
[14.0][IMP] Allows SelectVariantPopup to be updated when chained to itself

### DIFF
--- a/pos_product_template/static/src/js/SelectVariantPopup.js
+++ b/pos_product_template/static/src/js/SelectVariantPopup.js
@@ -24,6 +24,23 @@ odoo.define("pos_product_template.SelectVariantPopup", function (require) {
                 ptav_unavailable_ids: [],
                 all_attributes_chosen: false,
             });
+
+            this._mountPopup(template);
+        }
+
+        willUpdateProps(nextProp) {
+            var template = this.env.pos.db.get_template_by_id(nextProp.template_id);
+            this._mountPopup(template);
+            super.willUpdateProps(nextProp);
+        }
+
+        _mountPopup(template) {
+            this.state.ptav = [];
+            this.state.attributes = [];
+            this.state.template = template;
+            this.state.products = [];
+            this.state.ptav_id_selected = {};
+
             var ptav = Array.from(
                 new Set(
                     template.product_template_attribute_value_ids.map((x) =>


### PR DESCRIPTION
While trying to chain the "SelectVariantPopup" several times with itself, it was found that the popup information is not updated from the second showPopup call. As OWL apparently reuses the popup component from the previous call, it does not call the constructor again and consequently the popup is not updated with the information from the new showPopup call.

To solve the problem, the popup assembly logic was extracted to a function called both in the constructor and in the "willUpdateProps" hook