### PR TITLE
[ADD] pos_receipt_xml_header_footer

### DIFF
--- a/pos_receipt_xml_header_footer/__manifest__.py
+++ b/pos_receipt_xml_header_footer/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright 2022 Coop IT Easy SCRLfs
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Point of Sale XML in Header and Footer of Receipt",
+    "summary": """
+        Add the ability to use XML/HTML in the header and footer of a receipt""",
+    "version": "12.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "Coop IT Easy SCRLfs, Odoo Community Association (OCA)",
+    "maintainers": ["carmenbianca"],
+    "website": "https://github.com/OCA/pos",
+    "category": "Point of Sale",
+    "depends": ["point_of_sale"],
+    "data": [],
+    "qweb": ["static/src/xml/pos.xml"],
+    "demo": [],
+}

--- a/pos_receipt_xml_header_footer/readme/CONTRIBUTORS.rst
+++ b/pos_receipt_xml_header_footer/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Coop IT Easy SCRLfs <https://coopiteasy.be>`_:
+
+  * Carmen Bianca Bakker

--- a/pos_receipt_xml_header_footer/readme/DESCRIPTION.rst
+++ b/pos_receipt_xml_header_footer/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module adds support for ``header_xml`` and ``footer_xml`` in the PosTicket
+XML template.

--- a/pos_receipt_xml_header_footer/readme/USAGE.rst
+++ b/pos_receipt_xml_header_footer/readme/USAGE.rst
@@ -1,0 +1,18 @@
+To use XML (Odoo QWeb) and HTML in the headers and footers of your receipts, do
+the following:
+
+1. Open the Point of Sale application.
+2. Go to Configuration → Point of Sale, and select your POS.
+3. Enable 'Header & Footer'.
+4. Prepend your header or footer with a single line containing ``<!DOCTYPE QWEB``.
+
+For example, to use line breaks::
+
+  <!DOCTYPE QWEB
+  Hello<br />
+  world!
+
+Or to use QWeb templating magic::
+
+  <!DOCTYPE QWEB
+  <t t-esc='receipt.cashier'/> helped you today.

--- a/pos_receipt_xml_header_footer/static/src/xml/pos.xml
+++ b/pos_receipt_xml_header_footer/static/src/xml/pos.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<template id="template_id" name="template_name">
+
+    <t t-extend="PosTicket">
+        <t t-jquery="t[t-if='receipt.header']" t-operation="before">
+            <t t-if="receipt.header_xml">
+                <div style='text-align:center'>
+                    <t t-raw='receipt.header_xml' />
+                </div>
+            </t>
+        </t>
+        <t t-jquery="t[t-if='receipt.footer']" t-operation="before">
+            <t t-if='receipt.footer_xml'>
+                <br />
+                <div style='text-align:center'>
+                    <t t-raw='receipt.footer_xml' />
+                </div>
+            </t>
+        </t>
+    </t>
+</template>

--- a/setup/pos_receipt_xml_header_footer/odoo/addons/pos_receipt_xml_header_footer
+++ b/setup/pos_receipt_xml_header_footer/odoo/addons/pos_receipt_xml_header_footer
@@ -1,0 +1,1 @@
+../../../../pos_receipt_xml_header_footer

--- a/setup/pos_receipt_xml_header_footer/setup.py
+++ b/setup/pos_receipt_xml_header_footer/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Original PR here: https://github.com/coopiteasy/addons/pull/200

At @legalsylvain 's request, let's put this in the OCA.

---

In Odoo 12, there exist two XML templates that are both receipts:
PosTicket and XmlReceipt. PosTicket is shown on the cashier's screen,
and the more tightly defined XmlReceipt is sent to the ESC POC printer.
In future Odoo versions, I believe they have been unified into
OrderReceipt.
    
For reasons unknown to me, PosTicket does not contain support for
`header_xml` and `footer_xml`, but XmlReceipt does. This module fixes
that.

---

Internal task: https://gestion.coopiteasy.be/web#id=7746&view_type=form&model=project.task