### PR TITLE
[FIX][14.0] parsing fixed amount for discount

### DIFF
--- a/pos_fixed_discount/static/src/js/FixedDiscountButton.js
+++ b/pos_fixed_discount/static/src/js/FixedDiscountButton.js
@@ -17,7 +17,7 @@ odoo.define("pos_fixed_discount.FixedDiscountButton", function (require) {
                 startingValue: 0,
             });
             if (confirmed) {
-                var val = Math.round(Math.max(0, Math.min(100, parseFloat(payload))));
+                var val = Math.round(parseFloat(payload));
                 this.apply_discount(val);
             }
         }


### PR DESCRIPTION
The original line is obviously 1:1 copy from percentual discount which aimed to get value between 0 and 100 (percent) but in case of fixed discount doesn't make any sense and actually caps any input at 100.