### PR TITLE
[FIX][14.0] pos_empty_home: Missing attributes in tags

### DIFF
--- a/pos_empty_home/static/src/xml/pos_empty_home.xml
+++ b/pos_empty_home/static/src/xml/pos_empty_home.xml
@@ -6,7 +6,12 @@
     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 -->
 <templates id="template" xml:space="preserve">
-    <t t-inherit="point_of_sale.ProductList" t-inherit-mode="extension">
+    <t
+        t-name="ProductList"
+        t-inherit="point_of_sale.ProductList"
+        t-inherit-mode="extension"
+        owl="1"
+    >
         <xpath expr="//div[hasclass('product-list-empty')]" position="after">
             <p
                 t-if="props.products.length == 0 &amp;&amp; (!props.category || props.category.id == 0)"


### PR DESCRIPTION
When trying to inherit the component from the module, it started showing errors because it was not defined with the necessary attributes in the OWL tag. Initially, this doesn't seem to be a problem in terms of installation, but it ends up generating this unexpected behavior.

This PR just adds those missing elements.