### PR TITLE
[FIX][12.0] pos_order_to_sale_order : allow to create sale order from PoS when the products are only services

### DIFF
--- a/pos_order_to_sale_order/models/sale_order.py
+++ b/pos_order_to_sale_order/models/sale_order.py
@@ -49,8 +49,8 @@ class SaleOrder(models.Model):
         if action in ["confirmed", "delivered"]:
             sale_order.action_confirm()
 
-        # mark picking as delivered
-        if action == "delivered":
+        # mark picking as delivered (in case of non services products)
+        if action == "delivered" and sale_order.delivery_count:
             # Mark all moves are delivered
             for move in sale_order.mapped(
                     "picking_ids.move_ids_without_package"):


### PR DESCRIPTION
**Rational :** 
- Open your PoS
- begin a pos order, selecting only a service product
- set a customer
- try to create a delivered order
- -> there is an blocking error

**Analysis**
- confirm picking should not be called, if there are not picking associated to the created order


Trivial patch, thanks for your review.

GRAP Ticket 747 CC @quentinDupont 