### PR TITLE
[14.0] [FIX] pos_receipt_hide_price: Fix taxes showing with hide price

### DIFF
--- a/pos_receipt_hide_price/static/src/xml/OrderReceipt.xml
+++ b/pos_receipt_hide_price/static/src/xml/OrderReceipt.xml
@@ -82,10 +82,12 @@
     </xpath>
 
     <!-- Total Taxes -->
-    <xpath expr="//t[@t-foreach='receipt.tax_details']/div" position="attributes">
+    <!-- Both of these are needed to reliably hide taxes -->
+    <!-- This is counterintuitive but is the odoo xpath behavior -->
+    <xpath expr="//t[@t-if='isTaxIncluded']/div" position="attributes">
       <attribute name="t-att-class">{'oe_hidden': priceHidden}</attribute>
     </xpath>
-    <xpath expr="//t[@t-if='isTaxIncluded']/div" position="attributes">
+    <xpath expr="//t[@t-if='isTaxIncluded']//div" position="attributes">
       <attribute name="t-att-class">{'oe_hidden': priceHidden}</attribute>
     </xpath>
   </t>


### PR DESCRIPTION
Sometimes the current xpath does not work on taxes resulting in taxes shown with hide price on.
These xpaths seem to work more reliably.