### PR TITLE
[14.0][FIX] pos_margin: Frontend crash with pos_restaurant

### DIFF
--- a/pos_margin/static/src/js/OrderWidget.js
+++ b/pos_margin/static/src/js/OrderWidget.js
@@ -14,7 +14,7 @@ odoo.define("pos_margin.OrderWidget", function (require) {
             _updateSummary() {
                 super._updateSummary(...arguments);
                 var order = this.env.pos.get_order();
-                if (!order.get_orderlines().length) {
+                if (order === null || !order.get_orderlines().length) {
                     return;
                 }
                 var value_margin = document.getElementsByClassName("value-margin");


### PR DESCRIPTION
If you have pos_restaurant installed the frontend crashes when you try to transfer a pos order from one table to another.