### PR TITLE
[15.0] [FIX+IMP] `pos_event_sale`: compatibility with pos certification modules

### DIFF
--- a/pos_event_sale/models/event_registration.py
+++ b/pos_event_sale/models/event_registration.py
@@ -49,6 +49,13 @@ class EventRegistration(models.Model):
                 rec.payment_status = "not_paid"
         return res
 
+    def _check_auto_confirmation(self):
+        # OVERRIDE to disable auto confirmation for registrations created from
+        # PoS orders. We confirm them explicitly when the orders are paid.
+        if any(rec.pos_order_line_id for rec in self):
+            return False
+        return super()._check_auto_confirmation()
+
     @api.model_create_multi
     def create(self, vals_list):
         # Override to post the origin-link message.

--- a/pos_event_sale/models/pos_order.py
+++ b/pos_event_sale/models/pos_order.py
@@ -38,6 +38,7 @@ class PosOrder(models.Model):
 
     def action_pos_order_paid(self):
         res = super().action_pos_order_paid()
+        self.lines._cancel_refunded_event_registrations()
         to_confirm = self.event_registration_ids.filtered(lambda r: r.state == "draft")
         to_confirm.action_confirm()
         to_confirm._action_set_paid()

--- a/pos_event_sale/models/pos_order.py
+++ b/pos_event_sale/models/pos_order.py
@@ -45,7 +45,8 @@ class PosOrder(models.Model):
 
     def action_pos_order_cancel(self):
         res = super().action_pos_order_cancel()
-        self.event_registration_ids.action_cancel()
+        to_cancel = self.event_registration_ids.filtered(lambda r: r.state != "done")
+        to_cancel.action_cancel()
         return res
 
     def unlink(self):

--- a/pos_event_sale/models/pos_order.py
+++ b/pos_event_sale/models/pos_order.py
@@ -38,6 +38,7 @@ class PosOrder(models.Model):
 
     def action_pos_order_paid(self):
         res = super().action_pos_order_paid()
+        self.lines._cancel_negated_event_registrations()
         self.lines._cancel_refunded_event_registrations()
         to_confirm = self.event_registration_ids.filtered(lambda r: r.state == "draft")
         to_confirm.action_confirm()

--- a/pos_event_sale/models/pos_order.py
+++ b/pos_event_sale/models/pos_order.py
@@ -38,8 +38,9 @@ class PosOrder(models.Model):
 
     def action_pos_order_paid(self):
         res = super().action_pos_order_paid()
-        self.event_registration_ids.action_confirm()
-        self.event_registration_ids._action_set_paid()
+        to_confirm = self.event_registration_ids.filtered(lambda r: r.state == "draft")
+        to_confirm.action_confirm()
+        to_confirm._action_set_paid()
         return res
 
     def action_pos_order_cancel(self):

--- a/pos_event_sale/models/pos_order_line.py
+++ b/pos_event_sale/models/pos_order_line.py
@@ -34,7 +34,6 @@ class PosOrderLine(models.Model):
     def create(self, vals_list):
         records = super().create(vals_list)
         records._create_event_registrations()
-        records._cancel_refunded_event_registrations()
         return records
 
     def _prepare_event_registration_vals(self):

--- a/pos_event_sale/static/src/js/Screens/PaymentScreen.js
+++ b/pos_event_sale/static/src/js/Screens/PaymentScreen.js
@@ -17,7 +17,10 @@ odoo.define("pos_event_sale.PaymentScreen", function (require) {
                     order.event_registrations = await this.rpc({
                         model: "event.registration",
                         method: "search_read",
-                        domain: [["pos_order_id", "in", server_ids]],
+                        domain: [
+                            ["pos_order_id", "in", server_ids],
+                            ["state", "=", "open"],
+                        ],
                         kwargs: {context: session.user_context},
                     });
                 }

--- a/pos_event_sale/static/src/js/models/Orderline.js
+++ b/pos_event_sale/static/src/js/models/Orderline.js
@@ -118,6 +118,14 @@ odoo.define("pos_event_sale.Orderline", function (require) {
         /**
          * @override
          */
+        clone: function () {
+            const res = OrderlineSuper.clone.apply(this, arguments);
+            res.event_ticket_id = this.event_ticket_id;
+            return res;
+        },
+        /**
+         * @override
+         */
         init_from_JSON: function (json) {
             OrderlineSuper.init_from_JSON.apply(this, arguments);
             this.event_ticket_id = json.event_ticket_id;

--- a/pos_event_sale/tests/__init__.py
+++ b/pos_event_sale/tests/__init__.py
@@ -1,1 +1,2 @@
+from . import test_backend
 from . import test_frontend

--- a/pos_event_sale/tests/common.py
+++ b/pos_event_sale/tests/common.py
@@ -1,0 +1,228 @@
+# Copyright 2023 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from random import randint
+
+from odoo import fields
+
+from odoo.addons.point_of_sale.tests.common import TestPoSCommon
+from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+
+
+class PosEventMixin:
+    @classmethod
+    def setUpData(cls):
+        # Configure product
+        cls.product_event = cls.env.ref("event_sale.product_product_event")
+        cls.product_event.active = True
+        cls.product_event.available_in_pos = True
+        # Create event
+        cls.event = cls.env["event.event"].create(
+            {
+                "name": "Les Misérables",
+                "event_type_id": cls.env.ref("event.event_type_0").id,
+                "date_begin": fields.Datetime.start_of(fields.Datetime.now(), "day"),
+                "date_end": fields.Datetime.end_of(fields.Datetime.now(), "day"),
+                "stage_id": cls.env.ref("event.event_stage_booked").id,
+                "seats_limited": True,
+                "seats_max": 10,
+            }
+        )
+        cls.ticket_kids = cls.env["event.event.ticket"].create(
+            {
+                "name": "Kids",
+                "product_id": cls.product_event.id,
+                "event_id": cls.event.id,
+                "price": 0.0,
+                "seats_limited": True,
+                "seats_max": 5,
+            }
+        )
+        cls.ticket_regular = cls.env["event.event.ticket"].create(
+            {
+                "name": "Standard",
+                "product_id": cls.product_event.id,
+                "event_id": cls.event.id,
+                "price": 15.0,
+            }
+        )
+
+
+class TestPoSEventCommon(TestPoSCommon, PosEventMixin):
+    @classmethod
+    def setUpClass(cls, **kwargs):
+        super().setUpClass(**kwargs)
+        cls.setUpData()
+        cls.env.user.groups_id += cls.env.ref("event.group_event_user")
+        cls.basic_config.iface_event_sale = True
+        cls.config = cls.basic_config
+        # Open session
+        cls.config.open_session_cb(check_coa=False)
+        cls.pos_session = cls.config.current_session_id
+        cls.currency = cls.pos_session.currency_id
+        cls.pricelist = cls.pos_session.config_id.pricelist_id
+        cls.pos_session.set_cashbox_pos(0.0, None)
+        # Used to generate unique order ids
+        cls._nextId = 0
+
+    @classmethod
+    def _create_order_line_data(cls, product=None, quantity=1.0, discount=0.0, fp=None):
+        cls._nextId += 1
+        price_unit = cls.pricelist.get_product_price(product, quantity, False)
+        tax_ids = fp.map_tax(product.taxes_id) if fp else product.taxes_id
+        price_unit_after_discount = price_unit * (1 - discount / 100.0)
+        tax_values = (
+            tax_ids.compute_all(price_unit_after_discount, cls.currency, quantity)
+            if tax_ids
+            else {
+                "total_excluded": price_unit * quantity,
+                "total_included": price_unit * quantity,
+            }
+        )
+        return {
+            "discount": discount,
+            "id": cls._nextId,
+            "pack_lot_ids": [],
+            "price_unit": price_unit,
+            "product_id": product.id,
+            "price_subtotal": tax_values["total_excluded"],
+            "price_subtotal_incl": tax_values["total_included"],
+            "qty": quantity,
+            "tax_ids": [(6, 0, tax_ids.ids)],
+        }
+
+    @classmethod
+    def _create_event_order_line_data(
+        cls, ticket=None, quantity=1.0, discount=0.0, fp=None
+    ):
+        cls._nextId += 1
+        product = ticket.product_id
+        product_lst_price = product.lst_price
+        product_price = cls.pricelist.get_product_price(product, quantity, False)
+        price_unit = product_price / product_lst_price * ticket.price
+        tax_ids = (
+            fp.map_tax(ticket.product_id.taxes_id) if fp else ticket.product_id.taxes_id
+        )
+        price_unit_after_discount = price_unit * (1 - discount / 100.0)
+        tax_values = (
+            tax_ids.compute_all(price_unit_after_discount, cls.currency, quantity)
+            if tax_ids
+            else {
+                "total_excluded": price_unit * quantity,
+                "total_included": price_unit * quantity,
+            }
+        )
+        return {
+            "discount": discount,
+            "id": cls._nextId,
+            "pack_lot_ids": [],
+            "price_unit": price_unit,
+            "product_id": ticket.product_id.id,
+            "price_subtotal": tax_values["total_excluded"],
+            "price_subtotal_incl": tax_values["total_included"],
+            "qty": quantity,
+            "tax_ids": [(6, 0, tax_ids.ids)],
+            "event_ticket_id": ticket.id,
+        }
+
+    @classmethod
+    def _create_random_uid(cls):
+        return "%05d-%03d-%04d" % (randint(1, 99999), randint(1, 999), randint(1, 9999))
+
+    @classmethod
+    def _create_order_data(
+        cls,
+        lines=None,
+        event_lines=None,
+        partner=False,
+        is_invoiced=False,
+        payments=None,
+        uid=None,
+    ):
+        """Create a dictionary mocking data created by the frontend"""
+        default_fiscal_position = cls.config.default_fiscal_position_id
+        fiscal_position = (
+            partner.property_account_position_id if partner else default_fiscal_position
+        )
+        uid = uid or cls._create_random_uid()
+        # Lines
+        order_lines = []
+        if lines:
+            order_lines.extend(
+                [
+                    cls._create_order_line_data(**line, fp=fiscal_position)
+                    for line in lines
+                ]
+            )
+        if event_lines:
+            order_lines.extend(
+                [
+                    cls._create_event_order_line_data(**line, fp=fiscal_position)
+                    for line in event_lines
+                ]
+            )
+        # Payments
+        total_amount_incl = sum(line["price_subtotal_incl"] for line in order_lines)
+        if payments is None:
+            default_cash_pm = cls.config.payment_method_ids.filtered(
+                lambda pm: pm.is_cash_count
+            )[:1]
+            if not default_cash_pm:
+                raise Exception(
+                    "There should be a cash payment method set in the pos.config."
+                )
+            payments = [
+                dict(
+                    amount=total_amount_incl,
+                    name=fields.Datetime.now(),
+                    payment_method_id=default_cash_pm.id,
+                )
+            ]
+        else:
+            payments = [
+                dict(amount=amount, name=fields.Datetime.now(), payment_method_id=pm.id)
+                for pm, amount in payments
+            ]
+        # Order data
+        total_amount_base = sum(line["price_subtotal"] for line in order_lines)
+        return {
+            "data": {
+                "amount_paid": sum(payment["amount"] for payment in payments),
+                "amount_return": 0,
+                "amount_tax": total_amount_incl - total_amount_base,
+                "amount_total": total_amount_incl,
+                "creation_date": fields.Datetime.to_string(fields.Datetime.now()),
+                "fiscal_position_id": fiscal_position.id,
+                "pricelist_id": cls.config.pricelist_id.id,
+                "lines": [(0, 0, line) for line in order_lines],
+                "name": "Order %s" % uid,
+                "partner_id": partner and partner.id,
+                "pos_session_id": cls.pos_session.id,
+                "sequence_number": 2,
+                "statement_ids": [(0, 0, payment) for payment in payments],
+                "uid": uid,
+                "user_id": cls.env.user.id,
+                "to_invoice": is_invoiced,
+            },
+            "id": uid,
+            "to_invoice": is_invoiced,
+        }
+
+    @classmethod
+    def _create_from_ui(cls, order_list, draft=False):
+        if not isinstance(order_list, (list, tuple)):
+            order_list = [order_list]
+        order_data_list = [cls._create_order_data(**order) for order in order_list]
+        res = cls.env["pos.order"].create_from_ui(order_data_list, draft=draft)
+        order_ids = [order["id"] for order in res]
+        return cls.env["pos.order"].browse(order_ids)
+
+
+class TestPoSEventHttpCommon(TestPointOfSaleHttpCommon, PosEventMixin):
+    @classmethod
+    def setUpClass(cls, **kwargs):
+        super().setUpClass(**kwargs)
+        cls.setUpData()
+        cls.env.user.groups_id += cls.env.ref("event.group_event_user")
+        cls.main_pos_config.iface_event_sale = True
+        cls.main_pos_config.open_session_cb(check_coa=False)

--- a/pos_event_sale/tests/test_backend.py
+++ b/pos_event_sale/tests/test_backend.py
@@ -1,0 +1,89 @@
+# Copyright 2023 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests import tagged
+
+from .common import TestPoSEventCommon
+
+
+@tagged("post_install", "-at_install")
+class TestPoSEvent(TestPoSEventCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.order = cls._create_from_ui(
+            dict(
+                event_lines=[
+                    dict(ticket=cls.ticket_kids, quantity=2),
+                    dict(ticket=cls.ticket_regular, quantity=1),
+                ]
+            )
+        )
+
+    def test_action_open_registrations(self):
+        action = self.order.action_open_event_registrations()
+        self.assertEqual(action["type"], "ir.actions.act_window")
+
+    def test_event_pos_price_subtotal(self):
+        self.assertEqual(self.event.pos_price_subtotal, self.order.amount_total)
+
+    def test_event_action_view_pos_orders(self):
+        action = self.event.action_view_pos_orders()
+        self.assertEqual(self.env["pos.order"].search(action["domain"]), self.order)
+
+    def test_order_refund(self):
+        refund = self.env["pos.order"].browse(self.order.refund()["res_id"])
+        self.env["pos.make.payment"].with_context(
+            active_ids=refund.ids,
+            active_id=refund.id,
+            active_model=refund._name,
+        ).create(
+            {
+                "payment_method_id": self.config.payment_method_ids[0].id,
+                "amount": refund.amount_total,
+            }
+        ).check()
+        self.assertTrue(
+            all(reg.state == "cancel" for reg in self.order.event_registration_ids)
+        )
+
+    def test_order_cancel(self):
+        done_registrations = self.order.event_registration_ids[-2:]
+        open_registrations = self.order.event_registration_ids - done_registrations
+        done_registrations.action_set_done()
+        self.order.action_pos_order_cancel()
+        self.assertTrue(
+            all(reg.state == "cancel" for reg in open_registrations),
+            "Open registrations should be cancelled with the order",
+        )
+        self.assertTrue(
+            all(reg.state == "done" for reg in done_registrations),
+            "Done registrations should remain done",
+        )
+
+    def test_order_with_negated_registrations(self):
+        order = self._create_from_ui(
+            dict(
+                event_lines=[
+                    dict(ticket=self.ticket_kids, quantity=2),
+                    dict(ticket=self.ticket_kids, quantity=-2),
+                    dict(ticket=self.ticket_regular, quantity=1),
+                ]
+            )
+        )
+        kids_registrations = order.event_registration_ids.filtered(
+            lambda r: r.event_ticket_id == self.ticket_kids
+        )
+        self.assertEqual(len(kids_registrations), 2)
+        self.assertTrue(
+            all(reg.state == "cancel" for reg in kids_registrations),
+            "Kids registrations should be cancelled (negated)",
+        )
+        regular_registrations = order.event_registration_ids.filtered(
+            lambda r: r.event_ticket_id == self.ticket_regular
+        )
+        self.assertEqual(len(regular_registrations), 1)
+        self.assertTrue(
+            all(reg.state == "open" for reg in regular_registrations),
+            "Regular registrations should be confirmed",
+        )

--- a/pos_event_sale/tests/test_frontend.py
+++ b/pos_event_sale/tests/test_frontend.py
@@ -2,98 +2,28 @@
 # @author Iván Todorovich <ivan.todorovich@camptocamp.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from datetime import datetime
-
-from odoo import fields
 from odoo.tests import tagged
 
-from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+from .common import TestPoSEventHttpCommon
 
 
 @tagged("post_install", "-at_install")
-class TestUi(TestPointOfSaleHttpCommon):
-    @classmethod
-    def setUpClass(cls, **kwargs):
-        super().setUpClass(**kwargs)
-        cls.env.user.groups_id += cls.env.ref("event.group_event_user")
-        cls.main_pos_config.iface_event_sale = True
-        # Configure product
-        cls.product_event = cls.env.ref("event_sale.product_product_event")
-        cls.product_event.active = True
-        cls.product_event.available_in_pos = True
-        # Create event
-        cls.event = cls.env["event.event"].create(
-            {
-                "name": "Les Misérables",
-                "event_type_id": cls.env.ref("event.event_type_0").id,
-                "date_begin": datetime.combine(
-                    fields.Date.today(), datetime.min.time()
-                ),
-                "date_end": datetime.combine(fields.Date.today(), datetime.max.time()),
-                "stage_id": cls.env.ref("event.event_stage_booked").id,
-                "seats_limited": True,
-                "seats_max": 10,
-            }
-        )
-        cls.ticket_kids = cls.env["event.event.ticket"].create(
-            {
-                "name": "Kids",
-                "product_id": cls.product_event.id,
-                "event_id": cls.event.id,
-                "price": 0.0,
-                "seats_limited": True,
-                "seats_max": 5,
-            }
-        )
-        cls.ticket_regular = cls.env["event.event.ticket"].create(
-            {
-                "name": "Standard",
-                "product_id": cls.product_event.id,
-                "event_id": cls.event.id,
-                "price": 15.0,
-            }
-        )
-
+class TestPoSEventHttp(TestPoSEventHttpCommon):
     def test_pos_event_sale_basic_tour(self):
-        self.main_pos_config.open_session_cb(check_coa=False)
         self.start_tour(
             f"/pos/ui?config_id={self.main_pos_config.id}",
             "EventSaleTour",
             login="accountman",
         )
-        # Check POS Order (last created order)
-        pos_order = self.env["pos.order"].search([], order="id desc", limit=1)
-        # Check registrations
-        self.assertEqual(pos_order.event_registrations_count, 3)
-        for reg in pos_order.event_registration_ids:
-            self.assertEqual(reg.state, "open")
-        # Check action open registrations
-        action = pos_order.action_open_event_registrations()
-        self.assertEqual(action["type"], "ir.actions.act_window")
-        # Total sold amount for the event
-        self.assertEqual(self.event.pos_price_subtotal, 30.0)
-        action = self.event.action_view_pos_orders()
-        self.assertEqual(self.env["pos.order"].search(action["domain"]), pos_order)
-        # Refund the order
-        refund = self.env["pos.order"].browse(pos_order.refund()["res_id"])
-        # Pay the refund
-        self.env["pos.make.payment"].with_context(
-            active_ids=refund.ids,
-            active_id=refund.id,
-            active_model=refund._name,
-        ).create(
-            {
-                "payment_method_id": self.main_pos_config.payment_method_ids[0].id,
-                "amount": refund.amount_total,
-            }
-        ).check()
-        for reg in pos_order.event_registration_ids:
-            self.assertEqual(reg.state, "cancel")
+        order = self.env["pos.order"].search([], order="id desc", limit=1)
+        self.assertTrue(
+            all(reg.state == "open" for reg in order.event_registration_ids),
+            "Registrations should be confirmed",
+        )
 
     def test_pos_event_sale_availability_tour(self):
         self.event.seats_max = 5
         self.ticket_kids.seats_max = 3
-        self.main_pos_config.open_session_cb(check_coa=False)
         self.start_tour(
             f"/pos/ui?config_id={self.main_pos_config.id}",
             "EventSaleAvailabilityTour",

--- a/pos_event_sale_session/models/pos_order_line.py
+++ b/pos_event_sale_session/models/pos_order_line.py
@@ -26,6 +26,14 @@ class PosOrderLine(models.Model):
             res["event_session_id"] = self.event_session_id.id
         return res
 
+    def _find_event_registrations_to_negate(self):
+        # OVERRIDE to match also by event_session_id
+        return (
+            super()
+            ._find_event_registrations_to_negate()
+            .filtered(lambda r: r.session_id == self.event_session_id)
+        )
+
     def _export_for_ui(self, orderline):
         # OVERRIDE to add event_session_id
         res = super()._export_for_ui(orderline)

--- a/pos_event_sale_session/static/src/js/models/Orderline.js
+++ b/pos_event_sale_session/static/src/js/models/Orderline.js
@@ -52,6 +52,14 @@ odoo.define("pos_event_sale_session.Orderline", function (require) {
         /**
          * @override
          */
+        clone: function () {
+            const res = OrderlineSuper.clone.apply(this, arguments);
+            res.event_session_id = this.event_session_id;
+            return res;
+        },
+        /**
+         * @override
+         */
         init_from_JSON: function (json) {
             OrderlineSuper.init_from_JSON.apply(this, arguments);
             this.event_session_id = json.event_session_id;


### PR DESCRIPTION
Negated lines are particularly useful with PoS modules that disable the removal
of pos orderlines through the use of ``disallowLineQuantityChange``.

This is the case of `l10n_fr_pos_cert` module, for example. But there are other
core modules doing it, too.

In this case, added order lines can't be removed. Instead, the cashier is
encouraged to add a negative to 'cancel' the original one.

e.g.:

Adds a line with 10 tickets.
Then, adds a line with -10 tickets.

This should be almost the same as removing the first line: no actual
registration should be confirmed in the end, as we're reverting this sale.


----

Easier to review commit by commit