### PR TITLE
[IMP][15.0] Remove duplication of event.type.ticket code in event.event.ticket

### DIFF
--- a/pos_event_sale/models/event_ticket.py
+++ b/pos_event_sale/models/event_ticket.py
@@ -14,14 +14,3 @@ class EventTypeTicket(models.Model):
         "Please note that for the ticket to be available in the Point of Sale, "
         "the ticket's product has to be available there, too.",
     )
-
-
-class EventTicket(models.Model):
-    _inherit = "event.event.ticket"
-
-    available_in_pos = fields.Boolean(
-        related="product_id.available_in_pos",
-        help="This is configured on the related Product.\n\n"
-        "Please note that for the ticket to be available in the Point of Sale, "
-        "the ticket's product has to be available there, too.",
-    )


### PR DESCRIPTION
EventEventTicket inherits from EventTypeTicket, so we don't need to duplicate the field declaration, if it is the same in both modules. 
This eases overriding, as we need to override only one model, if we expect the same behavior in both.