### PR TITLE
[14.0][FIX] pos_payment_method_cashdro: floating point quirks

### DIFF
--- a/pos_payment_method_cashdro/static/src/js/payment_cashdro.js
+++ b/pos_payment_method_cashdro/static/src/js/payment_cashdro.js
@@ -47,7 +47,7 @@ odoo.define("pos_payment_method_cashdro.payment", function (require) {
             // Cashdro treats decimals as positions in an integer we also have
             // to deal with floating point computing to avoid decimals at the
             // end or the drawer will reject our request.
-            const amount = parseInt(order.get_due(payment_line).toFixed(2) * 100, 10);
+            const amount = Math.round(order.get_due(payment_line) * 100);
             const res = await this._cashdro_request(
                 this._cashdro_payment_url({amount: amount})
             );


### PR DESCRIPTION
Overcome floting point issues: https://stackoverflow.com/a/588014

For expample 2.3 * 100 ->  229.99999999999997

cc @Tecnativa TT42574

ping @pedrobaeza 