### PR TITLE
[14.0][FIX] pos_session_pay_invoice: exclude orders createds with this module on POS

### DIFF
--- a/pos_session_pay_invoice/__init__.py
+++ b/pos_session_pay_invoice/__init__.py
@@ -1,3 +1,4 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
+from . import models
 from . import wizard

--- a/pos_session_pay_invoice/models/__init__.py
+++ b/pos_session_pay_invoice/models/__init__.py
@@ -1,0 +1,1 @@
+from . import pos_order

--- a/pos_session_pay_invoice/models/pos_order.py
+++ b/pos_session_pay_invoice/models/pos_order.py
@@ -1,0 +1,25 @@
+# Copyright 2023 Jose Zambudio - Aures Tic <jose@aurestic.es>
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import api, models
+from odoo.osv.expression import AND
+
+
+class PosOrder(models.Model):
+    _inherit = "pos.order"
+
+    @api.model
+    def search_paid_order_ids(self, config_id, domain, limit, offset):
+        """Orders paid without reference are filtered so that there is no
+        error when exporting them.
+        (odoo/odoo/blob/14.0/addons/point_of_sale/models/pos_order.py#L712)"""
+        with_ref_domain = [
+            ("pos_reference", "!=", False),
+        ]
+        new_domain = AND([domain, with_ref_domain])
+        return super().search_paid_order_ids(
+            config_id,
+            new_domain,
+            limit,
+            offset,
+        )


### PR DESCRIPTION
When **Manage Orders** it's active we can get all paid orders from POS.

If a payment has been made with this module from the backend, the payment is generated without `Receipt Number`. 

When entering the POS and looking for the orders already paid, it gives the error when exporting the order that does not have this field established.:
![Screenshot_114](https://github.com/OCA/pos/assets/4418005/5ecf747c-8512-4d5f-8539-fde639051056)

I propose to add to the domain of paid orders those that have the field set, excluding those created by this module.
