### PR TITLE
[14.0][FIX] pos_order_mgmt: Overlapping return orders

### DIFF
--- a/pos_order_mgmt/static/src/js/RefundOrderButton.js
+++ b/pos_order_mgmt/static/src/js/RefundOrderButton.js
@@ -48,7 +48,7 @@ odoo.define("pos_order_mgmt.RefundOrderButton", function (require) {
             this._prepare_orderlines_from_order(order, refund_order);
 
             // Get Name
-            order.name = _t("Refund ") + refund_order.uid;
+            order.name = _t("Refund ") + order.uid;
 
             // Get to invoice
             order.set_to_invoice(refund_order.to_invoice);


### PR DESCRIPTION
If an order is returned (from the frontend), the concatenation of "Refund" + uid of the original order is currently indicated in the `pos_reference` field of the new order.

There is a problem here, because if several refunds of an order are made, only the 1st one is recorded, since the value of the `pos_reference` of the following orders already exists, so it is not recorded from the [**create_from_ui**](https://github.com/odoo/odoo/blob/14.0/addons/point_of_sale/models/pos_order.py#L550) method.

For Example:
 - We create an order with => pos_reference = _Order 06393-028-0119_:
   - Product_1: 5 units
   - Product_2: 5 units
   - Product_3: 5 units
- We return the Product_3 => pos_reference = _Refund 06393-028-0119_
- We return Product_2 => pos_reference = _Refund 06393-028-0119_ <- As this `pos_reference` already exists it is not processed at https://github.com/odoo/odoo/blob/14.0/addons/point_of_sale/models/pos_order.py#L569

To solve this, it is decided to no link the original order `uid` to the refund `pos_reference` make a unique reference for each refund, so it would be:
- We create an order with => pos_reference = _Order 06393-028-0119_
   - Product_1: 5 units
   - Product_2: 5 units
   - Product_3: 5 units
- We return Product_3 => pos_reference = _Refund 06393-028-0120_
- We return Product_2 => pos_reference = _Refund 06393-028-0121_

Internally since it gives linked and its delivery notes the return order to the original by means of the module `pos_order_return`. 

@chienandalu  