### PR TITLE
[14.0][FIX] pos_order_return: Returns and sales are allowed on the same order.

### DIFF
--- a/pos_order_return/tests/test_pos_order_return.py
+++ b/pos_order_return/tests/test_pos_order_return.py
@@ -49,7 +49,17 @@ class TestPOSOrderReturn(common.SavepointCase):
                 "taxes_id": False,
             }
         )
+        cls.product_3 = cls.env["product.product"].create(
+            {
+                "name": "Test product 3",
+                "standard_price": 1.0,
+                "type": "product",
+                "pos_allow_negative_qty": True,
+                "taxes_id": False,
+            }
+        )
         cls.PosOrder = cls.env["pos.order"]
+        cls.PosOrderLine = cls.env["pos.order.line"]
         cls.pos_config = cls.env.ref("point_of_sale.pos_config_main")
         cls.pos_config.write(
             {
@@ -65,8 +75,8 @@ class TestPOSOrderReturn(common.SavepointCase):
                 "partner_id": cls.partner.id,
                 "pricelist_id": cls.partner.property_product_pricelist.id,
                 "amount_tax": 0,
-                "amount_total": 2700,
-                "amount_paid": 2700,
+                "amount_total": 1350,
+                "amount_paid": 1350,
                 "amount_return": 0,
                 "lines": [
                     (
@@ -75,7 +85,7 @@ class TestPOSOrderReturn(common.SavepointCase):
                         {
                             "name": "POSLINE/0001",
                             "product_id": cls.product_1.id,
-                            "price_unit": 450,
+                            "price_unit": 225,
                             "price_subtotal": 450,
                             "price_subtotal_incl": 450,
                             "qty": 2.0,
@@ -87,7 +97,7 @@ class TestPOSOrderReturn(common.SavepointCase):
                         {
                             "name": "POSLINE/0002",
                             "product_id": cls.product_2.id,
-                            "price_unit": 450,
+                            "price_unit": 225,
                             "price_subtotal": 450,
                             "price_subtotal_incl": 450,
                             "qty": 2.0,
@@ -99,7 +109,7 @@ class TestPOSOrderReturn(common.SavepointCase):
                         {
                             "name": "POSLINE/0003",
                             "product_id": cls.product_1.id,
-                            "price_unit": 450,
+                            "price_unit": 225,
                             "price_subtotal": 450,
                             "price_subtotal_incl": 450,
                             "qty": 2.0,
@@ -175,5 +185,120 @@ class TestPOSOrderReturn(common.SavepointCase):
         pos_make_payment.with_context(active_id=refund_order.id).check()
         # Partner balance is 1350
         self.assertEqual(
-            sum(self.partner.mapped("invoice_ids.amount_total_signed")), 1350
+            sum(self.partner.mapped("invoice_ids.amount_total_signed")), 675.0
+        )
+
+    def __new_sale(self, qty, lines_qty_to_return, new_product):
+        partial_refund = (
+            self.env["pos.partial.return.wizard"]
+            .with_context(
+                {
+                    "active_ids": self.pos_order.ids,
+                    "active_id": self.pos_order.id,
+                }
+            )
+            .create({})
+        )
+        for line_index, return_qty in lines_qty_to_return:
+            partial_refund.line_ids[line_index].qty = return_qty
+        partial_refund.confirm()
+        refund_order = self.pos_order.refund_order_ids
+        # Customer exchanges 3 items for another product POSLINE/0004
+        self.PosOrderLine.create(
+            {
+                "name": "POSLINE/0004",
+                "order_id": refund_order.id,
+                "product_id": new_product.id,
+                "price_unit": 225,
+                "price_subtotal": 225 * qty,
+                "price_subtotal_incl": 225 * qty,
+                "qty": qty,
+            }
+        )
+        refund_order._onchange_amount_all()
+        pos_make_payment = (
+            self.env["pos.make.payment"]
+            .with_context(
+                {
+                    "active_ids": refund_order.ids,
+                    "active_id": refund_order.id,
+                }
+            )
+            .create({})
+        )
+        pos_make_payment.with_context(active_id=refund_order.id).check()
+        return refund_order
+
+    def test_pos_order_full_refund_and_new_equal_sale(self):
+        # The customer exchanges 3 items for the same quantity of another product.
+        refund_order = self.__new_sale(
+            3.0,
+            [
+                (0, 1.0),  # POSLINE/0001
+                (2, 2.0),  # POSLINE/0003
+            ],
+            self.product_2,
+        )
+        self.assertEqual(len(refund_order), 1)
+        self.assertEqual(len(refund_order.lines), 3)
+        self.assertEqual(
+            sum(self.partner.mapped("invoice_ids.amount_total_signed")), 1350.0
+        )
+
+    def test_pos_order_full_refund_and_new_lower_sale(self):
+        # Customer exchanges 3 items for 2 of another product
+        refund_order = self.__new_sale(
+            2.0,
+            [
+                (0, 1.0),  # POSLINE/0001
+                (2, 2.0),  # POSLINE/0003
+            ],
+            self.product_2,
+        )
+        self.assertEqual(len(refund_order), 1)
+        self.assertEqual(len(refund_order.lines), 3)
+        self.assertEqual(
+            sum(self.partner.mapped("invoice_ids.amount_total_signed")), 1125.0
+        )
+
+    def test_pos_order_full_refund_and_new_higher_sale(self):
+        # Customer exchanges 3 items for 4 of another product.
+        refund_order = self.__new_sale(
+            4.0,
+            [
+                (0, 1.0),  # POSLINE/0001
+                (2, 2.0),  # POSLINE/0003
+            ],
+            self.product_2,
+        )
+        self.assertEqual(len(refund_order), 1)
+        self.assertEqual(len(refund_order.lines), 3)
+        self.assertEqual(
+            sum(self.partner.mapped("invoice_ids.amount_total_signed")), 1575.0
+        )
+
+    def test_pos_order_several_refund_and_new_sale(self):
+        # The customer refund an order placed through a previous refund.
+        refund_order = self.__new_sale(
+            3.0,
+            [
+                (0, 1.0),  # POSLINE/0001
+                (2, 2.0),  # POSLINE/0003
+            ],
+            self.product_2,
+        )
+        self.assertEqual(len(refund_order), 1)
+        self.assertEqual(len(refund_order.lines), 3)
+        self.pos_order = self.PosOrder.search([], limit=1, order="id desc")
+        refund_order = self.__new_sale(
+            5.0,
+            [
+                (2, 3.0),  # POSLINE/0004
+            ],
+            self.product_3,
+        )
+        self.assertEqual(len(refund_order), 1)
+        self.assertEqual(len(refund_order.lines), 2)
+        self.assertEqual(
+            sum(self.partner.mapped("invoice_ids.amount_total_signed")), 1800.0
         )


### PR DESCRIPTION
Currently if you use the `pos_order_return` module together with `pos_order_mgmt` you can perform order returns from the frontend.

From here, currently the frontend user can make a return and take advantage of the same order to make a sale (for example a replacement of a product, he returns one and we sell him another of the same, higher or lower price).

The current problem is that `pos_order_return` does not allow this, when the new order is persisted only the lines of the return are processed, ignoring those of the new sale.

With this change, we support these types of sales, so that an order can end up having 2 pickings, one with the returns of a previous order and another delivery note with the new sale.