### PR TITLE
16.0 fix eslint

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -126,7 +126,7 @@ rules:
   no-self-compare: warn
   no-sequences: warn
   no-shadow-restricted-names: warn
-  no-shadow: warn
+  # no-shadow: warn
   no-sparse-arrays: warn
   no-sync: warn
   no-this-before-super: warn

--- a/pos_order_reorder/static/src/js/Screens/TicketScreen/ControlButtons/ReorderButton.esm.js
+++ b/pos_order_reorder/static/src/js/Screens/TicketScreen/ControlButtons/ReorderButton.esm.js
@@ -1,8 +1,8 @@
 /** @odoo-module **/
 
+import {Orderline} from "point_of_sale.models";
 import PosComponent from "point_of_sale.PosComponent";
 import Registries from "point_of_sale.Registries";
-import {Orderline} from "point_of_sale.models";
 
 class ReorderButton extends PosComponent {
     get isEmptyOrder() {

--- a/pos_payment_terminal/static/src/js/models.js
+++ b/pos_payment_terminal/static/src/js/models.js
@@ -25,7 +25,9 @@ odoo.define("pos_payment_terminal.models", function (require) {
             async after_load_server_data() {
                 for (var payment_method_id in this.payment_methods) {
                     var payment_method = this.payment_methods[payment_method_id];
-                    if (payment_method.use_payment_terminal == "oca_payment_terminal") {
+                    if (
+                        payment_method.use_payment_terminal === "oca_payment_terminal"
+                    ) {
                         this.config.use_proxy = true;
                     }
                 }


### PR DESCRIPTION
Hi all.
rational : when I contribute to OCA, when I run pre-commit locally, there is a lot of useless warnings.
So this PR : 
- fix 2 trivials eslint warn in 2 modules
- remove no-shadow because in my opinion, the syntax is valid, and used a lot of time in the OCA/pos project. 

Any point of view, @ivantodorovich ?