### PR TITLE
[FIX][16.0] pos_order_remove_line: clean toRefundLines when deleting a refunded orderline from remove-line-button

### DIFF
--- a/pos_order_remove_line/static/src/js/orderline.esm.js
+++ b/pos_order_remove_line/static/src/js/orderline.esm.js
@@ -15,7 +15,9 @@ const PosOrderline = (Orderline) =>
                 ev.stopPropagation();
                 ev.preventDefault();
                 this.selectLine();
-                order.remove_orderline(order.get_selected_orderline());
+                const selected_line = order.get_selected_orderline();
+                selected_line.set_quantity("remove");
+                order.remove_orderline(selected_line);
                 this.checkRewardLines(order);
             }
         }


### PR DESCRIPTION
In a refund order, if we delete a refunded orderline from remove-line-button, it stills says that orderline is being refunding.

Example:
1. Refund an orderline line.
![image](https://github.com/OCA/pos/assets/1337928/0dd02176-a81e-4e3c-8f25-2d4da3713e22)

3. Remove it from orderline button
![image](https://github.com/OCA/pos/assets/1337928/c5d4eb43-25c1-4038-8ac1-8c6704ab6d18)

5. Check that refunded orderline is still in "refunding".
![image](https://github.com/OCA/pos/assets/1337928/fca059a0-3e42-40d3-9270-729d1d5d7c1e)

4. If we click in the order, line is already deleted.
