### PR TITLE
[14.0] [FIX] pos_reset_search: wrong class name ProductsWidgetControlPanel

### DIFF
--- a/pos_reset_search/static/src/js/ProductScreen.js
+++ b/pos_reset_search/static/src/js/ProductScreen.js
@@ -23,7 +23,7 @@ odoo.define("pos_reset_search.ProductScreen", function (require) {
                             ProductWidgetChildren[key].el.className ===
                             "products-widget-control"
                         ) {
-                            ProductWidget = ProductWidgetChildren[key];
+                            ProductsWidgetControlPanel = ProductWidgetChildren[key];
                         }
                     }
                     if (ProductsWidgetControlPanel) {


### PR DESCRIPTION
@rousseldenis 
It seems the module pos_reset_search doesn't work currently (I tested on the runboat). I cannot say I understand all the logic in the JS code, but I suspect that the wrong class was called. It seems to work this way. 