### PR TITLE
[16.0][FIX] pos_partner_birthdate: partner birthdate field wasn't being saved from PoS

### DIFF
--- a/pos_partner_birthdate/__manifest__.py
+++ b/pos_partner_birthdate/__manifest__.py
@@ -14,7 +14,8 @@
     "depends": ["point_of_sale", "partner_contact_birthdate"],
     "assets": {
         "point_of_sale.assets": [
-            "pos_partner_birthdate/static/src/xml/ClientDetailsEdit.xml"
+            "pos_partner_birthdate/static/src/xml/ClientDetailsEdit.xml",
+            "pos_partner_birthdate/static/src/js/ClientDetailsEdit.esm.js",
         ]
     },
 }

--- a/pos_partner_birthdate/readme/CONTRIBUTORS.rst
+++ b/pos_partner_birthdate/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Emanuel Cino <ecino@compassion.ch>
+* Juan Carlos Bonilla Bravo <juancarlos.bonilla@factorlibre.com>

--- a/pos_partner_birthdate/static/src/js/ClientDetailsEdit.esm.js
+++ b/pos_partner_birthdate/static/src/js/ClientDetailsEdit.esm.js
@@ -1,0 +1,16 @@
+/** @odoo-module **/
+import PartnerDetailsEdit from "point_of_sale.PartnerDetailsEdit";
+import Registries from "point_of_sale.Registries";
+
+const PartnerDetailsEditBirthdate = (OriginalPartnerDetailsEdit) =>
+    class extends OriginalPartnerDetailsEdit {
+        setup() {
+            super.setup();
+            this.changes = {
+                ...this.changes,
+                birthdate_date: this.props.partner.birthdate_date || "",
+            };
+        }
+    };
+
+Registries.Component.extend(PartnerDetailsEdit, PartnerDetailsEditBirthdate);

--- a/pos_partner_birthdate/static/src/js/ClientDetailsEdit.esm.js
+++ b/pos_partner_birthdate/static/src/js/ClientDetailsEdit.esm.js
@@ -8,7 +8,7 @@ const PartnerDetailsEditBirthdate = (OriginalPartnerDetailsEdit) =>
             super.setup();
             this.changes = {
                 ...this.changes,
-                birthdate_date: this.props.partner.birthdate_date || "",
+                birthdate_date: this.props.partner.birthdate_date || null,
             };
         }
     };

--- a/pos_partner_birthdate/static/src/xml/ClientDetailsEdit.xml
+++ b/pos_partner_birthdate/static/src/xml/ClientDetailsEdit.xml
@@ -13,6 +13,7 @@
                     class="detail"
                     name="birthdate_date"
                     type="date"
+                    t-model="changes.birthdate_date"
                     t-on-change="captureChange"
                     t-att-value="props.partner.birthdate_date || ''"
                     placeholder="Birthdate"


### PR DESCRIPTION
Steps to reproduce:

1. Install module and open a pos session
2. Select a customer and edit its birthdate field
3. Check that birthdate field has not been saved on frontend/backend