### PR TITLE
[FIX] pos_customer_comment: fix bug with comment field on EditPartnerDetails screen

### DIFF
--- a/pos_customer_comment/__manifest__.py
+++ b/pos_customer_comment/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Point of Sale - Cashier Comment",
     "summary": "Display Customer comment in the PoS front office and allow"
     " to edit and save it by the cashier",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.0.1",
     "category": "Point of Sale",
     "maintainers": ["legalsylvain"],
     "author": "GRAP,Odoo Community Association (OCA)",
@@ -21,6 +21,7 @@
             "pos_customer_comment/static/src/css/pos_customer_comment.scss",
             "pos_customer_comment/static/src/xml/PartnerDetailsEdit.xml",
             "pos_customer_comment/static/src/xml/PartnerLine.xml",
+            "pos_customer_comment/static/src/js/PartnerDetailsEdit.esm.js",
         ],
         "web.assets_tests": [
             "pos_customer_comment/tests/tours/PosCustomerComment.tour.js",

--- a/pos_customer_comment/readme/CONTRIBUTORS.rst
+++ b/pos_customer_comment/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Sylvain LE GAL (https://twitter.com/legalsylvain)
+* Juan Carlos Bonilla <juancarlos.bonilla@factorlibre.com>

--- a/pos_customer_comment/static/src/js/PartnerDetailsEdit.esm.js
+++ b/pos_customer_comment/static/src/js/PartnerDetailsEdit.esm.js
@@ -1,0 +1,16 @@
+/** @odoo-module **/
+import PartnerDetailsEdit from "point_of_sale.PartnerDetailsEdit";
+import Registries from "point_of_sale.Registries";
+
+const PartnerDetailsEditComment = (OriginalPartnerDetailsEdit) =>
+    class extends OriginalPartnerDetailsEdit {
+        setup() {
+            super.setup();
+            this.changes = {
+                ...this.changes,
+                pos_comment: this.props.partner.pos_comment || "",
+            };
+        }
+    };
+
+Registries.Component.extend(PartnerDetailsEdit, PartnerDetailsEditComment);

--- a/pos_customer_comment/static/src/xml/PartnerDetailsEdit.xml
+++ b/pos_customer_comment/static/src/xml/PartnerDetailsEdit.xml
@@ -19,8 +19,8 @@
                     class="detail"
                     name="pos_comment"
                     style="height: 100px;"
+                    t-model="changes.pos_comment"
                     t-on-change="captureChange"
-                    t-att-value="props.partner.pos_comment || ''"
                     placeholder="Comment"
                 />
             </div>


### PR DESCRIPTION
This PR is a fix for changes made on [commit](https://github.com/odoo/odoo/commit/c585d82dc34c99cafee645c5a306f1a795b06c0c) changing its logic on EditPartnerDetails screen.

PR related: https://github.com/OCA/pos/pull/1031