### PR TITLE
[16.0][FIX] bug on printing coupons redeemed

### DIFF
--- a/pos_loyalty_redeem_payment/models/pos_order.py
+++ b/pos_loyalty_redeem_payment/models/pos_order.py
@@ -47,15 +47,14 @@ class PosOrder(models.Model):
 
     @api.model
     def get_loy_card_reports_from_order(self, order_ids):
-        card_ids = (
+        coupons = (
             self.env["pos.order"].browse(order_ids).mapped("payment_ids.coupon_id")
         )
-        loy_cards = self.env["loyalty.card"].search([("id", "in", card_ids.ids)])
-        if not loy_cards:
+        if not coupons:
             return False
         report_per_program = {}
         coupon_per_report = defaultdict(list)
-        for coupon in loy_cards:
+        for coupon in coupons:
             trigger = "create"
             if coupon.points == 0:
                 trigger = "points_reach"

--- a/pos_loyalty_redeem_payment/models/pos_order.py
+++ b/pos_loyalty_redeem_payment/models/pos_order.py
@@ -59,7 +59,10 @@ class PosOrder(models.Model):
             trigger = "create"
             if coupon.points == 0:
                 trigger = "points_reach"
-            if coupon.program_id not in report_per_program:
+            if (
+                coupon.program_id not in report_per_program
+                or not report_per_program[coupon.program_id]
+            ):
                 report_per_program[
                     coupon.program_id
                 ] = coupon.program_id.communication_plan_ids.filtered(


### PR DESCRIPTION
**Steps to reproduce:**
1. Redeem full points on a `coupon A` with id lower than `coupon B`
2. Redeem partially `coupon B` in same order.
3. After processing the order, I won't print `coupon B` with remaining points.