### PR TITLE
[16.0][FIX] pos_order_remove_line: Trigger

### DIFF
--- a/pos_order_remove_line/static/src/js/orderline.esm.js
+++ b/pos_order_remove_line/static/src/js/orderline.esm.js
@@ -10,23 +10,10 @@ import Registries from "point_of_sale.Registries";
 const PosOrderline = (Orderline) =>
     class extends Orderline {
         async removeLine(ev) {
-            const order = this.env.pos.get_order();
-            if (order) {
-                ev.stopPropagation();
-                ev.preventDefault();
-                this.selectLine();
-                const selected_line = order.get_selected_orderline();
-                selected_line.set_quantity("remove");
-                order.remove_orderline(selected_line);
-                this.checkRewardLines(order);
-            }
-        }
-        // Dependecy-less suport to pos_loyalty
-        checkRewardLines(order) {
-            const anyRewardLine = order.orderlines.some((line) => line.is_reward_line);
-            if (anyRewardLine) {
-                order._updateRewards();
-            }
+            ev.stopPropagation();
+            ev.preventDefault();
+            this.selectLine();
+            this.trigger("update-selected-orderline", {buffer: null, key: "Backspace"});
         }
     };
 Registries.Component.extend(Orderline, PosOrderline);


### PR DESCRIPTION
Function logic is modified in order to use the numpad backspace trigger. 

Uses _**_updateSelectedOrderline()**_ method and works with any module installed and their extended methods, like **pos_loyalty**, executing all inherited functions and fixing the problem that doesn't recalculates loyalty points when pos_loyalty is installed and removes an order line. 