### PR TITLE
[14.0][FIX] pos_customer_display: set use_proxy=true

### DIFF
--- a/pos_customer_display/static/src/js/models.js
+++ b/pos_customer_display/static/src/js/models.js
@@ -39,6 +39,9 @@ odoo.define("pos_customer_display.models", function (require) {
 
         after_load_server_data: function () {
             this.proxy.load_customer_display_format_file();
+            if (this.config.iface_customer_display) {
+                this.config.use_proxy = true;
+            }
             return PosModelSuper.prototype.after_load_server_data.call(this);
         },
     });


### PR DESCRIPTION
I found this bug on a setup where the only device using POSbox/pywebdriver was a Bixolon customer display (payment terminal and receipt printer didn't use the POSbox/pywebdriver).