### PR TITLE
[16.0] [IMP] pos_loyalty_redeem_payment Not allow loyalty payment for refund

### DIFF
--- a/pos_loyalty_redeem_payment/static/src/js/PaymentScreen.esm.js
+++ b/pos_loyalty_redeem_payment/static/src/js/PaymentScreen.esm.js
@@ -152,6 +152,16 @@ export const CouponPosPaymentScreen = (OriginalPaymentScreen) =>
                 this.applyProgramAsPaymentMethod(paymentMethod);
                 return;
             }
+            if (
+                (order.get_due() < 0 || order.get_subtotal() < 0) &&
+                paymentMethod.used_for_loyalty_program
+            ) {
+                this.showPopup("ErrorPopup", {
+                    title: this.env._t("Error"),
+                    body: this.env._t("You cannot use this payment method for refund"),
+                });
+                return;
+            }
             super.addNewPaymentLine(...arguments);
         }
 


### PR DESCRIPTION
The flow for refund is not manage in the backend - so just want to disable for the POS to use the payment method on refund