### PR TITLE
[14.0][IMP] pos_no_cash_bank_statement: bank statement name generation

### DIFF
--- a/pos_no_cash_bank_statement/models/pos_session.py
+++ b/pos_no_cash_bank_statement/models/pos_session.py
@@ -39,7 +39,7 @@ class PosSession(models.Model):
                             0,
                             {
                                 "journal_id": pay_method.cash_journal_id.id,
-                                "name": self.name,
+                                "name": "%s %s" % (self.name, pay_method.name),
                             },
                         )
                         for pay_method in payment_methods_bank_statement


### PR DESCRIPTION
The goal of this modification is to have different bank statement names per payment method, so avoid to have error messages such as:
```
Some Cash Registers are already posted. Please reset them to new in order to close the session.
Cash Registers: ['POS/02594', 'POS/02594']
```