### PR TITLE
[14.0][FIX] pos_order_mgmt: Return with positive amounts

### DIFF
--- a/pos_order_mgmt/static/src/js/ProductScreen.js
+++ b/pos_order_mgmt/static/src/js/ProductScreen.js
@@ -1,0 +1,42 @@
+/* Copyright Aures Tic - Jose Zambudio <jose@aurestic.es>
+   License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl) */
+odoo.define("pos_order_mgmt.ProductScreen", function (require) {
+    "use strict";
+
+    const ProductScreen = require("point_of_sale.ProductScreen");
+    const Registries = require("point_of_sale.Registries");
+
+    const PosOrderMgmtProductScreen = (ProductScreen) =>
+        class extends ProductScreen {
+            async _onClickPay() {
+                if (
+                    this.env.pos
+                        .get_order()
+                        .orderlines.any(
+                            (line) =>
+                                line.returned_orderline_id &&
+                                Math.abs(line.quantity) > line.max_return_qty
+                        )
+                ) {
+                    const {confirmed} = await this.showPopup("ConfirmPopup", {
+                        title: this.env._t("Incorrect quantities"),
+                        body: this.env._t(
+                            `It is returning more than the quantity delivered.
+                            Would you like to proceed anyway?`
+                        ),
+                        confirmText: this.env._t("Yes"),
+                        cancelText: this.env._t("No"),
+                    });
+                    if (confirmed) {
+                        return super._onClickPay(...arguments);
+                    }
+                } else {
+                    return super._onClickPay(...arguments);
+                }
+            }
+        };
+
+    Registries.Component.extend(ProductScreen, PosOrderMgmtProductScreen);
+
+    return PosOrderMgmtProductScreen;
+});

--- a/pos_order_mgmt/static/src/js/RefundOrderButton.js
+++ b/pos_order_mgmt/static/src/js/RefundOrderButton.js
@@ -69,6 +69,8 @@ odoo.define("pos_order_mgmt.RefundOrderButton", function (require) {
                     merge: false,
                     extras: {
                         return_pack_lot_names: orderline.pack_lot_names,
+                        returned_orderline_id: orderline.id,
+                        max_return_qty: quantity,
                     },
                 });
             });

--- a/pos_order_mgmt/static/src/js/models.js
+++ b/pos_order_mgmt/static/src/js/models.js
@@ -5,9 +5,11 @@
 odoo.define("pos_order_mgmt.models", function (require) {
     "use strict";
 
-    var models = require("point_of_sale.models");
+    const models = require("point_of_sale.models");
+    const field_utils = require("web.field_utils");
 
-    var _orderproto = models.Order.prototype;
+    const _orderproto = models.Order.prototype;
+    const _orderLineProto = models.Orderline.prototype;
 
     models.Order = models.Order.extend({
         init_from_JSON: function (json) {
@@ -23,6 +25,21 @@ odoo.define("pos_order_mgmt.models", function (require) {
             var res = _orderproto.export_for_printing.apply(this, arguments);
             res.returned_order_id = this.returned_order_id;
             return res;
+        },
+    });
+
+    models.Orderline = models.Orderline.extend({
+        set_quantity: function (quantity, keep_price) {
+            if (quantity !== "remove") {
+                quantity =
+                    typeof quantity === "number"
+                        ? quantity
+                        : field_utils.parse.float(String(quantity)) || 0;
+                if (this.returned_orderline_id) {
+                    quantity = Math.abs(quantity) * -1;
+                }
+            }
+            return _orderLineProto.set_quantity.call(this, quantity, keep_price);
         },
     });
 });

--- a/pos_order_mgmt/views/assets.xml
+++ b/pos_order_mgmt/views/assets.xml
@@ -12,6 +12,10 @@
             />
             <script
                 type="text/javascript"
+                src="/pos_order_mgmt/static/src/js/ProductScreen.js"
+            />
+            <script
+                type="text/javascript"
                 src="/pos_order_mgmt/static/src/js/RefundOrderButton.js"
             />
             <script


### PR DESCRIPTION
When making a return, the POS user can change the return quantity into positive. If the user does not realise this, the error message ["Please specify at least one non-zero quantity"](https://github.com/odoo/odoo/blob/14.0/addons/stock/wizard/stock_picking_return.py#L167) is displayed at the end of the order. leaving the order to be synchronised, always giving the same error.

I propose that when making the return from the POS, this line should always be forced to a negative amount. 

In addition, a ConfirmPopup has been added to make sure that the user is aware that he is making a return of more than the amount sold.