### PR TITLE
[16.0][FIX] pos_partner_birthdate: fixing this.changes state

### DIFF
--- a/pos_partner_birthdate/static/src/js/ClientDetailsEdit.esm.js
+++ b/pos_partner_birthdate/static/src/js/ClientDetailsEdit.esm.js
@@ -1,4 +1,5 @@
 /** @odoo-module **/
+const {useState} = owl;
 import PartnerDetailsEdit from "point_of_sale.PartnerDetailsEdit";
 import Registries from "point_of_sale.Registries";
 
@@ -6,10 +7,10 @@ const PartnerDetailsEditBirthdate = (OriginalPartnerDetailsEdit) =>
     class extends OriginalPartnerDetailsEdit {
         setup() {
             super.setup();
-            this.changes = {
+            this.changes = useState({
                 ...this.changes,
                 birthdate_date: this.props.partner.birthdate_date || null,
-            };
+            });
         }
     };
 


### PR DESCRIPTION
use `useState` when add `birthdate_date` to `changes` state