### PR TITLE
[16.0][FIX] pos_partner_birthdate: Fixing conflict t-model vs t-att-value

### DIFF
--- a/pos_partner_birthdate/static/src/xml/ClientDetailsEdit.xml
+++ b/pos_partner_birthdate/static/src/xml/ClientDetailsEdit.xml
@@ -15,7 +15,6 @@
                     type="date"
                     t-model="changes.birthdate_date"
                     t-on-change="captureChange"
-                    t-att-value="props.partner.birthdate_date || ''"
                     placeholder="Birthdate"
                 />
             </div>


### PR DESCRIPTION
After merged this PR #1071 now `changes.birthdate_date` is reactive.
If we use `t-model`, there is no need to use the `t-att-value`, because this will cause abnormal behavior.

Before this changes: 
![Before del t-att-value](https://github.com/OCA/pos/assets/19549819/a61f8fed-0eab-4d21-b002-182996946751)

After this changes: 
![After del t-att-value](https://github.com/OCA/pos/assets/19549819/6c692879-dcb2-4016-9c31-337dc34bb55b)
