### PR TITLE
[16.0][IMP] pos_order_to_sale_order : use customer note and correctly prepare sale.order.line name fields

### DIFF
--- a/pos_order_to_sale_order/models/sale_order.py
+++ b/pos_order_to_sale_order/models/sale_order.py
@@ -33,6 +33,17 @@ class SaleOrder(models.Model):
         order_vals = self._prepare_from_pos(order_data)
         sale_order = self.create(order_vals)
 
+        for (i, line_data) in enumerate(order_data["lines"]):
+            if line_data[2].get("customer_note", False):
+                order_line = sale_order.order_line.filtered(
+                    lambda x: x.sequence == i + 1
+                )
+                order_line.write(
+                    {
+                        "name": f"{order_line.name}\n{line_data[2].get('customer_note', False)}"
+                    }
+                )
+
         # Confirm Sale Order
         if action in ["confirmed", "delivered", "invoiced"]:
             sale_order.action_confirm()

--- a/pos_order_to_sale_order/models/sale_order.py
+++ b/pos_order_to_sale_order/models/sale_order.py
@@ -31,18 +31,9 @@ class SaleOrder(models.Model):
     def create_order_from_pos(self, order_data, action):
         # Create Draft Sale order
         order_vals = self._prepare_from_pos(order_data)
-        sale_order = self.create(order_vals)
-
-        for (i, line_data) in enumerate(order_data["lines"]):
-            if line_data[2].get("customer_note", False):
-                order_line = sale_order.order_line.filtered(
-                    lambda x: x.sequence == i + 1
-                )
-                order_line.write(
-                    {
-                        "name": f"{order_line.name}\n{line_data[2].get('customer_note', False)}"
-                    }
-                )
+        sale_order = self.with_context(
+            pos_order_lines_data=[x[2] for x in order_data.get("lines", [])]
+        ).create(order_vals)
 
         # Confirm Sale Order
         if action in ["confirmed", "delivered", "invoiced"]:

--- a/pos_order_to_sale_order/models/sale_order.py
+++ b/pos_order_to_sale_order/models/sale_order.py
@@ -14,8 +14,8 @@ class SaleOrder(models.Model):
         session = PosSession.browse(order_data["pos_session_id"])
         SaleOrderLine = self.env["sale.order.line"]
         order_lines = [
-            Command.create(SaleOrderLine._prepare_from_pos(line[2]))
-            for line in order_data["lines"]
+            Command.create(SaleOrderLine._prepare_from_pos(i + 1, line_data[2]))
+            for (i, line_data) in enumerate(order_data["lines"])
         ]
         return {
             "partner_id": order_data["partner_id"],

--- a/pos_order_to_sale_order/models/sale_order_line.py
+++ b/pos_order_to_sale_order/models/sale_order_line.py
@@ -10,15 +10,9 @@ class SaleOrderLine(models.Model):
 
     @api.model
     def _prepare_from_pos(self, sequence, order_line_data):
-        ProductProduct = self.env["product.product"]
-        product = ProductProduct.browse(order_line_data["product_id"])
-        product_name = product.name
-        if order_line_data.get("customer_note"):
-            product_name += "\n" + order_line_data["customer_note"]
         return {
             "sequence": sequence,
             "product_id": order_line_data["product_id"],
-            "name": product_name,
             "product_uom_qty": order_line_data["qty"],
             "discount": order_line_data["discount"],
             "price_unit": order_line_data["price_unit"],

--- a/pos_order_to_sale_order/models/sale_order_line.py
+++ b/pos_order_to_sale_order/models/sale_order_line.py
@@ -9,13 +9,14 @@ class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
     @api.model
-    def _prepare_from_pos(self, order_line_data):
+    def _prepare_from_pos(self, sequence, order_line_data):
         ProductProduct = self.env["product.product"]
         product = ProductProduct.browse(order_line_data["product_id"])
         product_name = product.name
         if order_line_data.get("customer_note"):
             product_name += "\n" + order_line_data["customer_note"]
         return {
+            "sequence": sequence,
             "product_id": order_line_data["product_id"],
             "name": product_name,
             "product_uom_qty": order_line_data["qty"],

--- a/pos_order_to_sale_order/models/sale_order_line.py
+++ b/pos_order_to_sale_order/models/sale_order_line.py
@@ -18,3 +18,14 @@ class SaleOrderLine(models.Model):
             "price_unit": order_line_data["price_unit"],
             "tax_id": order_line_data["tax_ids"],
         }
+
+    def _get_sale_order_line_multiline_description_sale(self):
+        res = super()._get_sale_order_line_multiline_description_sale()
+
+        for (i, line_data) in enumerate(
+            self.env.context.get("pos_order_lines_data", [])
+        ):
+            if line_data.get("customer_note", False) and self.sequence == i + 1:
+                res += "\n" + line_data.get("customer_note")
+
+        return res


### PR DESCRIPTION
context : when using pos_order_to_sale_order in V16 : 
- the name of the sale.order.line is not like when we create sale order from UI. (the default_code is not used, the sale_description is not used...)
- On the other hand, if cashier set a customer note in the PoS, the value is lost.

This PR fixes both problem.

Supersed : #1065

Previous implementation : 

![image](https://github.com/OCA/pos/assets/3407482/52c41d01-cb70-49b5-99cf-5008152acb55)

New implementation : 

![image](https://github.com/OCA/pos/assets/3407482/51ba13f8-858e-495e-b972-4205ec3e659b)
