### PR TITLE
[FIX] pos_loyalty_redeem_payment : bad translation break pre-commit

### DIFF
--- a/pos_loyalty_redeem_payment/i18n/fr.po
+++ b/pos_loyalty_redeem_payment/i18n/fr.po
@@ -158,7 +158,7 @@ msgstr "Un paiement électronique est déjà en cours."
 #: code:addons/pos_loyalty_redeem_payment/models/pos_config.py:0
 #, fuzzy, python-format
 msgid "This coupon has to be redeemed from payment mode (%s)."
-msgstr "Ce coupon a été remboursé."
+msgstr "Ce coupon doit être échangé à partir du mode de paiement (%s)"
 
 #. module: pos_loyalty_redeem_payment
 #: model:ir.model.fields,field_description:pos_loyalty_redeem_payment.field_pos_payment_method__used_for_loyalty_program


### PR DESCRIPTION
rational : 
- CI is broken in V16.0 (pre-commit test fail)
- The log is : 
```
 Checks for .po[t] files..................................................Failed
- hook id: oca-checks-po
- exit code: 1

****po-python-parse-printf****
pos_loyalty_redeem_payment/i18n/fr.po:160 Translation string couldn't be parsed correctly using str%variables TypeError('not all arguments converted during string formatting') - [po-python-parse-printf]
```
(https://github.com/OCA/pos/actions/runs/6825111513/job/18562312074#step:7:16)

- This comes from this commit. (https://github.com/OCA/pos/commit/ad6c09cdc265a7b251fea71deff886c871b0658c#diff-4769375039e1c4e6f5f5e3a15b66e763d6462659049524eddaff52b8b0f4e4beR161) done by @LESTRAT21 via weblate.

This PR fixes the translation.

