### PR TITLE
[15.0][FIX] pos_report_session_summary: fix error when printing

### DIFF
--- a/pos_report_session_summary/views/report_session_summary.xml
+++ b/pos_report_session_summary/views/report_session_summary.xml
@@ -65,28 +65,16 @@
                                 <td><span t-field="statement.name" /></td>
                                 <td><span t-field="statement.journal_id" /></td>
                                 <td class="text-right">
-                                    <span
-                                            t-field="statement.balance_start"
-                                            t-options='{"widget": "monetary", "display_currency": "statement.currency_id"}'
-                                        />
+                                    <span t-field="statement.balance_start" />
                                 </td>
                                 <td class="text-right">
-                                    <span
-                                            t-field="statement.total_entry_encoding"
-                                            t-options='{"widget": "monetary", "display_currency": "statement.currency_id"}'
-                                        />
+                                    <span t-field="statement.total_entry_encoding" />
                                 </td>
                                 <td class="text-right">
-                                    <span
-                                            t-field="statement.balance_end_real"
-                                            t-options='{"widget": "monetary", "display_currency": "statement.currency_id"}'
-                                        />
+                                    <span t-field="statement.balance_end_real" />
                                 </td>
                                 <td class="text-right">
-                                    <span
-                                            t-field="statement.difference"
-                                            t-options='{"widget": "monetary", "display_currency": "statement.currency_id"}'
-                                        />
+                                    <span t-field="statement.difference" />
                                 </td>
                                 <td
                                         class="text-right"
@@ -143,10 +131,7 @@
                                                 t-field="line.account_id"
                                             /></td>
                                     <td class="text-right">
-                                        <span
-                                                t-field="line.amount"
-                                                t-options='{"widget": "monetary", "display_currency": "statement.currency_id"}'
-                                            />
+                                        <span t-field="line.amount" />
                                     </td>
                                 </tr>
                             </tbody>


### PR DESCRIPTION
Is not possible to print the report. This pr fixes the error: 'str' object has no attribute 'decimal_places' when printing session summary