### PR TITLE
[FIX] pos_payment_change : check installation fo existing modules.

### DIFF
--- a/pos_payment_change/models/pos_config.py
+++ b/pos_payment_change/models/pos_config.py
@@ -36,7 +36,7 @@ class PosConfig(models.Model):
         module_states = (
             self.env["ir.module.module"]
             .sudo()
-            .search([("name", "=", "l10n_fr_certification")])
+            .search([("name", "=", "l10n_fr_pos_cert")])
             .mapped("state")
         )
         if "installed" not in module_states:


### PR DESCRIPTION
In old version, two certifications modules was present in odoo.  l10n_fr_pos_cert and l10n_fr_certification.  In odoo 16, only l10n_fr_pos_cert exists.

Fix : #1004 

@LESTRAT21, could you take a look on this one ? 