### PR TITLE
[15.0] [FIX] `pos_sale_pos_event_sale`: keep the event sale description after import

### DIFF
--- a/pos_sale_pos_event_sale/static/src/js/models.js
+++ b/pos_sale_pos_event_sale/static/src/js/models.js
@@ -27,6 +27,8 @@ odoo.define("pos_sale_pos_event_sale.models", function (require) {
                 );
                 this.event_ticket_id =
                     saleOrderLine.event_ticket_id && saleOrderLine.event_ticket_id[0];
+                // Force a recomputation through getEventSaleDescription
+                this.full_product_name = undefined;
             } else {
                 return OrderlineSuper.setQuantityFromSOL.apply(this, arguments);
             }


### PR DESCRIPTION
This fixes a regression introduced by the following upstream changes:

- https://github.com/odoo/odoo/commit/51776fcaae630233e79ac613f9479efa6967d04e
- https://github.com/odoo/odoo/commit/dbd766f1b87f91eefce7b6e5946856961fd96c70
- https://github.com/odoo/odoo/commit/5a0113a7d74ff8c429501e922c3cd1fae2535695

The Orderline's name was being set to the product description, loosing the event and event ticket information that was previously being displayed.

This caused our CI to fail, as the test was expecting the event sale description in there.

The fix is to clear the ``full_product_name`` property for imported event lines, such that the displayed name is recomputed from the event and event ticket.