### PR TITLE
[14.0][FIX] pos_order_return: empty returns

### DIFF
--- a/pos_order_return/models/pos_order.py
+++ b/pos_order_return/models/pos_order.py
@@ -145,7 +145,12 @@ class PosOrder(models.Model):
             if abs(to_return[move.product_id]) < move.quantity:
                 move.quantity = abs(to_return[move.product_id])
             to_return[move.product_id] -= move.quantity
-        picking = self.env["stock.picking"].browse(wizard.create_returns()["res_id"])
+        picking = self.env["stock.picking"].browse()
+        # Avoid empty returns which will block the validation
+        if any(wizard.product_return_moves.mapped("quantity")):
+            picking = self.env["stock.picking"].browse(
+                wizard.create_returns()["res_id"]
+            )
         normal_picking = self.env["stock.picking"]._create_picking_from_pos_order_lines(
             self._get_picking_destination().id,
             order_lines,


### PR DESCRIPTION
If by mistake a cashier creates an empty return, the order won't be synched as the backend code will raise an exception. The order will be stuck and everytime it tries to sync it will raise an error.

For the moment, avoid trying to create an empty picking return, although we should forbid it in UX in the first place.

cc @Tecnativa TT46400

please review @pedrobaeza 

fyi @zamberjo 