### PR TITLE
[IMP] pos_partner_firstname: set name invisible instead of readonly when is_company=False

### DIFF
--- a/pos_partner_firstname/static/src/xml/pos.xml
+++ b/pos_partner_firstname/static/src/xml/pos.xml
@@ -3,7 +3,9 @@
 
     <t t-inherit="point_of_sale.PartnerDetailsEdit" t-inherit-mode="extension">
         <xpath expr="//input[@name='name']" position="attributes">
-            <attribute name="t-att-readonly">!changes.is_company</attribute>
+            <attribute
+                name="t-attf-style"
+            >display: {{changes.is_company ? 'block': 'none'}}</attribute>
         </xpath>
         <xpath expr="//div[@class='partner-details-left']/div[1]" position="before">
             <div class="partner-detail">


### PR DESCRIPTION
From my experience with my end users, in POS partner form view, when is_company=False, they try to use the "name" field because it's not obvious that the field is readonly in the user interface. It's better to put that field invisible when is_company=false.