### PR TITLE
[16.0][FIX] pos_payment_change: ondelete='cascade' for O2M fields

### DIFF
--- a/pos_payment_change/wizards/pos_payment_change_wizard_new_line.py
+++ b/pos_payment_change/wizards/pos_payment_change_wizard_new_line.py
@@ -12,6 +12,7 @@ class PosPaymentChangeWizardLine(models.TransientModel):
     wizard_id = fields.Many2one(
         comodel_name="pos.payment.change.wizard",
         required=True,
+        ondelete="cascade",
     )
 
     new_payment_method_id = fields.Many2one(

--- a/pos_payment_change/wizards/pos_payment_change_wizard_old_line.py
+++ b/pos_payment_change/wizards/pos_payment_change_wizard_old_line.py
@@ -12,6 +12,7 @@ class PosPaymentChangeWizardOldLine(models.TransientModel):
     wizard_id = fields.Many2one(
         comodel_name="pos.payment.change.wizard",
         required=True,
+        ondelete="cascade",
     )
 
     old_payment_method_id = fields.Many2one(


### PR DESCRIPTION
Aims at fixing error such as:
```
2024-04-12 17:36:25,232 1887855 ERROR prod odoo.sql_db: bad query: DELETE FROM "pos_payment_change_wizard" WHERE id IN (3, 4)
ERROR: update or delete on table "pos_payment_change_wizard" violates foreign key constraint "pos_payment_change_wizard_new_line_wizard_id_fkey" on table "pos_payment_change_wizard_new_line"
DETAIL:  Key (id)=(3) is still referenced from table "pos_payment_change_wizard_new_line".
 
2024-04-12 17:36:25,238 1887855 ERROR prod odoo.addons.base.models.ir_autovacuum: Failed pos.payment.change.wizard()._transient_vacuum() 
Traceback (most recent call last):
  File "/home/odoo/erp/odoo/odoo/addons/base/models/ir_autovacuum.py", line 38, in _run_vacuum_cleaner
    func(model)
  File "/home/odoo/erp/odoo/odoo/models.py", line 6806, in _transient_vacuum
    self._transient_clean_rows_older_than(self._transient_max_hours * 60 * 60)
  File "/home/odoo/erp/odoo/odoo/models.py", line 6830, in _transient_clean_rows_older_than
    self.sudo().browse(ids).unlink()
  File "/home/odoo/erp/odoo/odoo/models.py", line 3597, in unlink
    cr.execute(query, (sub_ids,))
  File "/home/odoo/erp/odoo/odoo/sql_db.py", line 321, in execute
    res = self._obj.execute(query, params)
psycopg2.errors.ForeignKeyViolation: update or delete on table "pos_payment_change_wizard" violates foreign key constraint "pos_payment_change_wizard_new_line_wizard_id_fkey" on table "pos_payment_change_wizard_new_line"
DETAIL:  Key (id)=(3) is still referenced from table "pos_payment_change_wizard_new_line".

2024-04-12 17:36:25,520 1887855 INFO prod odoo.models.unlink: User #1 deleted pos.payment.change.wizard.new.line records with IDs: [3, 4] 
```