### PR TITLE
[16.0] pos_membership_extension : change membership category

### DIFF
--- a/pos_membership_extension/static/src/js/models.js
+++ b/pos_membership_extension/static/src/js/models.js
@@ -10,10 +10,8 @@ odoo.define("pos_membership_extension.models", function (require) {
 
     var _t = core._t;
 
-    // eslint-disable-next-line no-shadow
-    const OverloadProduct = (Product) =>
-        // eslint-disable-next-line no-shadow
-        class OverloadProduct extends Product {
+    const OverloadProduct = (OriginalProduct) =>
+        class extends OriginalProduct {
             /**
              * Return if it's allowed to sell the product to the partner.
              *
@@ -39,10 +37,8 @@ odoo.define("pos_membership_extension.models", function (require) {
         };
     Registries.Model.extend(Product, OverloadProduct);
 
-    // eslint-disable-next-line no-shadow
-    const OverloadOrder = (Order) =>
-        // eslint-disable-next-line no-shadow
-        class OverloadOrder extends Order {
+    const OverloadOrder = (OriginalOrder) =>
+        class extends OriginalOrder {
             /**
              * Overloaded function.
              * Check if the product of the order lines are allowed by the

--- a/pos_membership_extension/static/src/js/models.js
+++ b/pos_membership_extension/static/src/js/models.js
@@ -69,7 +69,6 @@ odoo.define("pos_membership_extension.models", function (require) {
                             `The following lines has been removed, as the product cannot be sold to this partner: ${bad_product_text}`
                         ),
                     });
-                    return;
                 }
 
                 return super.set_partner(...arguments);

--- a/pos_membership_extension/static/src/js/models.js
+++ b/pos_membership_extension/static/src/js/models.js
@@ -53,14 +53,15 @@ odoo.define("pos_membership_extension.models", function (require) {
              * @returns {Boolean} In any case, return the result of the super function.
              */
             set_partner(partner) {
-                var self = this;
                 var bad_product_list = [];
-                this.orderlines.forEach(function (orderline) {
+                var i = this.orderlines.length;
+                while (i--) {
+                    var orderline = this.orderlines[i];
                     if (!orderline.product.get_membership_allowed(partner)) {
                         bad_product_list.push(orderline.product.display_name);
-                        self.orderlines.remove(orderline);
+                        this.orderlines.splice(i, 1);
                     }
-                });
+                }
                 if (bad_product_list.length !== 0) {
                     var bad_product_text = bad_product_list.join(", ");
                     Gui.showPopup("ErrorPopup", {


### PR DESCRIPTION
**Use case :** 
- select a customer that belong to a membership category
- select then MANY products that are reserved to this membership category
- switch then to a "normal" customer that doesn't belong to the membership category

**Before :** 

- Not all lines are removed
- the customer is not changed.

**After**
- the customer is correctly changed
- all the lines are correctly removed.

Ref : https://stackoverflow.com/a/9882349