### PR TITLE
[14.0] [ADD] pos_product_available

### DIFF
--- a/pos_product_available/__init__.py
+++ b/pos_product_available/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/pos_product_available/__manifest__.py
+++ b/pos_product_available/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    "name": "Point of Sale Products Available",
+    "summary": """Visible products for each different Point of Sale""",
+    "category": "Point Of Sale",
+    "author": "Carlos Franco Cifuentes, Esment, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/pos",
+    "version": "14.0.0.1.0",
+    "license": "AGPL-3",
+    "depends": ["product", "point_of_sale"],
+    "data": [
+        "views/assets.xml",
+        "views/product_view.xml",
+        "views/pos_config_view.xml",
+    ],
+}

--- a/pos_product_available/i18n/es.po
+++ b/pos_product_available/i18n/es.po
@@ -1,0 +1,67 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* pos_product_available
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-11-16 09:35+0000\n"
+"PO-Revision-Date: 2023-11-16 10:36+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.4\n"
+
+#. module: pos_product_available
+#: model:ir.model.fields,field_description:pos_product_available.field_pos_config__available_product
+msgid "Available Product"
+msgstr "Productos Disponibles"
+
+#. module: pos_product_available
+#: model:ir.model.fields,field_description:pos_product_available.field_pos_config__display_name
+#: model:ir.model.fields,field_description:pos_product_available.field_product_template__display_name
+msgid "Display Name"
+msgstr "Nombre mostrado"
+
+#. module: pos_product_available
+#: model:ir.model.fields,field_description:pos_product_available.field_pos_config__id
+#: model:ir.model.fields,field_description:pos_product_available.field_product_template__id
+msgid "ID"
+msgstr ""
+
+#. module: pos_product_available
+#: model:ir.model.fields,field_description:pos_product_available.field_pos_config____last_update
+#: model:ir.model.fields,field_description:pos_product_available.field_product_template____last_update
+msgid "Last Modified on"
+msgstr "Última modificación el"
+
+#. module: pos_product_available
+#: model:ir.model.fields,field_description:pos_product_available.field_product_product__pos_center_ids
+#: model:ir.model.fields,field_description:pos_product_available.field_product_template__pos_center_ids
+msgid "POS Available"
+msgstr "PDV Disponibles"
+
+#. module: pos_product_available
+#: model:ir.model,name:pos_product_available.model_pos_config
+msgid "Point of Sale Config Visible Products"
+msgstr ""
+
+#. module: pos_product_available
+#: model:ir.model,name:pos_product_available.model_product_template
+msgid "Point of Sale Visible Product"
+msgstr ""
+
+#. module: pos_product_available
+#: model_terms:ir.ui.view,arch_db:pos_product_available.pos_config_view_form
+msgid "Products available for this Point of Sale"
+msgstr "Productos disponibles para este Punto de Venta"
+
+#. module: pos_product_available
+#: model:ir.model.fields,field_description:pos_product_available.field_pos_config__available_product_ids
+msgid "Restrict products for this point of sale"
+msgstr "Restringir productos para este punto de venta"

--- a/pos_product_available/models/__init__.py
+++ b/pos_product_available/models/__init__.py
@@ -1,0 +1,2 @@
+from . import product
+from . import pos_config

--- a/pos_product_available/models/pos_config.py
+++ b/pos_product_available/models/pos_config.py
@@ -1,0 +1,12 @@
+from odoo import fields, models
+
+
+class PosConfig(models.Model):
+    _inherit = "pos.config"
+    _description = "Point of Sale Config Visible Products"
+
+    available_product = fields.Boolean()
+    available_product_ids = fields.Many2many(
+        comodel_name="product.template",
+        string="Restrict products for this point of sale",
+    )

--- a/pos_product_available/models/product.py
+++ b/pos_product_available/models/product.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+    _description = "Point of Sale Visible Product"
+
+    pos_center_ids = fields.Many2many(
+        comodel_name="pos.config",
+        string="POS Available",
+    )

--- a/pos_product_available/pos_product_available/odoo/addons/pos_product_available
+++ b/pos_product_available/pos_product_available/odoo/addons/pos_product_available
@@ -1,0 +1,1 @@
+../../../../pos_product_available

--- a/pos_product_available/pos_product_available/setup.py
+++ b/pos_product_available/pos_product_available/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/pos_product_available/pos_product_available/setup.py
+++ b/pos_product_available/pos_product_available/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
 setuptools.setup(
-    setup_requires=['setuptools-odoo'],
+    setup_requires=["setuptools-odoo"],
     odoo_addon=True,
 )

--- a/pos_product_available/readme/CONTRIBUTORS.rst
+++ b/pos_product_available/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Carlos Franco Cifuentes <cfrancoc00@gmail.com>

--- a/pos_product_available/readme/DESCRIPTION.rst
+++ b/pos_product_available/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module gives the option to choose which products, 
+according to the categories available at the point of sale, 
+will be visible in these points of sale.

--- a/pos_product_available/readme/USAGE.rst
+++ b/pos_product_available/readme/USAGE.rst
@@ -1,0 +1,6 @@
+In points of sale that share a category with the "Restrict product categories" option, not all products in said categories must necessarily be sold.
+
+In some points of sale you can sell some products that are not available in another point of sale even though they share the category.
+
+To do this, this module has been created that gives the option to put in each product, in which points of sale they are visible, for these products to 
+appear in the points of sale, this point of sale must have configured that said category be displayed. of the products.

--- a/pos_product_available/static/src/js/models.js
+++ b/pos_product_available/static/src/js/models.js
@@ -1,0 +1,49 @@
+odoo.define("pos_product_available.models", function (require) {
+    "use strict";
+    var models = require("point_of_sale.models");
+
+    models.PosModel.prototype.models.some(function (model) {
+        if (model.model !== "product.product") {
+            return false;
+        }
+        model.domain = function (self) {
+            var domain = [
+                "&",
+                "&",
+                ["sale_ok", "=", true],
+                ["available_in_pos", "=", true],
+                "|",
+                ["company_id", "=", self.config.company_id[0]],
+                ["company_id", "=", false],
+            ];
+            if (
+                self.config.limit_categories &&
+                self.config.iface_available_categ_ids.length
+            ) {
+                domain.unshift("&");
+                domain.push([
+                    "pos_categ_id",
+                    "in",
+                    self.config.iface_available_categ_ids,
+                ]);
+                if (
+                    self.config.available_product &&
+                    self.config.available_product_ids.length
+                ) {
+                    domain.unshift("&");
+                    domain.push([
+                        "product_tmpl_id",
+                        "in",
+                        self.config.available_product_ids,
+                    ]);
+                }
+            }
+            if (self.config.iface_tipproduct) {
+                domain.unshift(["id", "=", self.config.tip_product_id[0]]);
+                domain.unshift("|");
+            }
+            return domain;
+        };
+        return true;
+    });
+});

--- a/pos_product_available/views/assets.xml
+++ b/pos_product_available/views/assets.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <template
+        name="point_of_sale assets inherit"
+        id="pos_assets_inherit"
+        inherit_id="point_of_sale.assets"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/pos_product_available/static/src/js/models.js"
+            />
+        </xpath>
+    </template>
+</odoo>

--- a/pos_product_available/views/pos_config_view.xml
+++ b/pos_product_available/views/pos_config_view.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="pos_config_view_form" model="ir.ui.view">
+        <field name="name">pos.config.form.view.inherit</field>
+        <field name="model">pos.config</field>
+        <field name="inherit_id" ref="point_of_sale.pos_config_view_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//div[@class='row mt16 o_settings_container']/div[@class='col-12 col-lg-6 o_setting_box']/div[@class='o_setting_left_pane']/field[@name='limit_categories']/../.."
+                position="after"
+            >
+                <div class="col-12 col-lg-6 o_setting_box">
+                    <div class="o_setting_left_pane">
+                        <field
+                            name="available_product"
+                            attrs="{'readonly': [('has_active_session','=', True)]}"
+                        />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="available_product" />
+                        <div class="text-muted">
+                            Products available for this Point of Sale
+                        </div>
+                        <div
+                            class="content-group mt16"
+                            attrs="{'invisible': [('available_product', '=', False)]}"
+                        >
+                            <field
+                                name="available_product_ids"
+                                domain="[('available_in_pos','=', True), ('pos_categ_id', 'in', iface_available_categ_ids)]"
+                                options="{'no_create': True}"
+                                widget="many2many_tags"
+                                attrs="{'readonly': True}"
+                            />
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/pos_product_available/views/product_view.xml
+++ b/pos_product_available/views/product_view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="product_template_form_view" model="ir.ui.view">
+        <field name="name">product.template.pos.form.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="point_of_sale.product_template_form_view" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//page[@name='pos']/group/group/field[@name='to_weight']"
+                position="after"
+            >
+                <field
+                    name="pos_center_ids"
+                    attrs="{'invisible': [('available_in_pos', '=', False)]}"
+                    options="{'no_create': True}"
+                    widget="many2many_tags"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
In the product configuration, a field has been added where it can be assigned to the point of sale where its sale is allowed.

This functionality serves to prevent all products with the configuration available in the POS from appearing in all points of sale.