### PR TITLE
[10.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/pos_remove_pos_category/__manifest__.py
+++ b/pos_remove_pos_category/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'POS Remove POS Category',
     'version': '10.0.2.0.1',
-    'author': 'Akretion, Camptocamp SA, ACSONE SA/NV, '
+    'author': 'Akretion, Camptocamp, ACSONE SA/NV, '
               'Odoo Community Association (OCA)',
     'category': 'Sales Management',
     'depends': [


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 10.0.