### PR TITLE
[12.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/pos_remove_pos_category/__manifest__.py
+++ b/pos_remove_pos_category/__manifest__.py
@@ -3,7 +3,7 @@
 {
     'name': 'POS Remove POS Category',
     'version': '12.0.2.0.1',
-    'author': 'Akretion, Camptocamp SA, ACSONE SA/NV, '
+    'author': 'Akretion, Camptocamp, ACSONE SA/NV, '
               'Odoo Community Association (OCA)',
     'category': 'Point of Sale',
     'depends': [


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 12.0.