### PR TITLE
[14.0][FIX] pos_sale_order_load: Fix ValueError Invalid field 'pos_allow_negative_qty'

### DIFF
--- a/pos_sale_order_load/tests/test_sale_order.py
+++ b/pos_sale_order_load/tests/test_sale_order.py
@@ -12,7 +12,6 @@ class TestPosCashMoveReason(SavepointCase):
                 "name": "Test product 1",
                 "standard_price": 1.0,
                 "type": "product",
-                "pos_allow_negative_qty": False,
                 "taxes_id": False,
                 "tracking": "lot",
             }


### PR DESCRIPTION
- Field pos_allow_negative_qty is set in pos_order_return and this module not depends on it. 
- Tests are failing on environments without pos_order_return installed. 
- Fix ValueError: Invalid field 'pos_allow_negative_qty' on model 'product.product'

@Tecnativa
TT49941
@pedrobaeza @victoralmau 

