### PR TITLE
[17.0][FIX] pos_lot_barcode: fix testcase

### DIFF
--- a/pos_lot_barcode/static/tests/tours/LotScanning.tour.esm.js
+++ b/pos_lot_barcode/static/tests/tours/LotScanning.tour.esm.js
@@ -35,6 +35,7 @@ registry.category("web_tour.tours").add("LotScanningInsteadofInputTour", {
     url: "/pos/ui",
     steps: () =>
         [
+            ProductScreen.confirmOpeningPopup(),
             ProductScreen.clickHomeCategory(),
             ProductScreen.clickDisplayedProduct("Lot Product 1"),
             scan_barcode("10120000515"),

--- a/pos_lot_selection/tests/test_frontend.py
+++ b/pos_lot_selection/tests/test_frontend.py
@@ -7,7 +7,7 @@ from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCom
 
 
 @odoo.tests.tagged("post_install", "-at_install")
-class TestLotScanning(TestPointOfSaleHttpCommon):
+class TestLotSelection(TestPointOfSaleHttpCommon):
     @classmethod
     def setUpClass(cls, chart_template_ref=None):
         super().setUpClass(chart_template_ref=chart_template_ref)

--- a/pos_product_expiry/tests/test_frontend.py
+++ b/pos_product_expiry/tests/test_frontend.py
@@ -9,7 +9,7 @@ from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCom
 
 
 @odoo.tests.tagged("post_install", "-at_install")
-class TestLotScanning(TestPointOfSaleHttpCommon):
+class TestLotProductExpiry(TestPointOfSaleHttpCommon):
     @classmethod
     def setUpClass(cls, chart_template_ref=None):
         super().setUpClass(chart_template_ref=chart_template_ref)


### PR DESCRIPTION
- as reported in some PRs ([#1208](https://github.com/OCA/pos/pull/1208), [#1230](https://github.com/OCA/pos/pull/1230),  [#1234](https://github.com/OCA/pos/pull/1234)) `pos_lot_barcode` tests were failing due a tour.
- turns out the root cause if that the `pos_lot_selection` and `pos_product_expiry`modules have the same test case class name as the `pos_lot_barcode` module.
- as a consequence, there was a conflict during the unittest TestSuite collection process.
- Beside, I add `ProductScreen.confirmOpeningPopup()` step in order to confirm the opening of the session.