### PR TITLE
[FIX] pos_product_label: Avoid to show extra content field in different formats at PoS

### DIFF
--- a/pos_product_label/static/src/PrintLabelPopup.esm.js
+++ b/pos_product_label/static/src/PrintLabelPopup.esm.js
@@ -26,6 +26,11 @@ export default class PrintLabelPopup extends AbstractAwaitablePopup {
             this.data.format = data.print_format.selection[0][0];
         });
     }
+
+    updateFormat(event) {
+        this.data.format = event.target.value;
+    }
+
     async confirm() {
         const order = this.env.pos.get_order();
         const productIds = [

--- a/pos_product_label/static/src/PrintLabelPopup.xml
+++ b/pos_product_label/static/src/PrintLabelPopup.xml
@@ -35,6 +35,7 @@
                                         t-model="data.format"
                                         t-att-id="format"
                                         t-att-value="format"
+                                        t-on-change="updateFormat"
                                     />
                                     <label
                                         t-att-for="format"
@@ -45,7 +46,7 @@
                         </div>
                     </section>
                     <section>
-                        <div>
+                        <div t-if="data.format == '2x7xprice'">
                             <label for="extraContent">Extra Content</label>
                             <textarea
                                 rows="4"


### PR DESCRIPTION
In backend, this field dissapear automatically when you click any other format that is not '2x7xprice'. This is because it's the only format that allows to have extra content in its label. This is a video that shows this functionallity at backend:

[backend.webm](https://github.com/user-attachments/assets/4d461952-a928-4231-844a-49faf3cc050e)


Before this changes, that behaviour didn't work at PoS, making this field editable in all formats.

[pos.webm](https://github.com/user-attachments/assets/d664a058-3fab-4406-a6b6-236f1185e516)

Now, with this changes the behaviour at PoS is the same than in backend, avoiding to modify the extra content field when it's not possible.

FL-556-3627

