### PR TITLE
[16.0][FIX] pos_stock_available_online: stock move updates

### DIFF
--- a/pos_stock_available_online/models/__init__.py
+++ b/pos_stock_available_online/models/__init__.py
@@ -1,5 +1,7 @@
 from . import pos_config
 from . import pos_session
 from . import res_config_settings
+from . import stock_notifier_pos_mixin
 from . import stock_quant
 from . import stock_warehouse
+from . import stock_move

--- a/pos_stock_available_online/models/stock_move.py
+++ b/pos_stock_available_online/models/stock_move.py
@@ -1,0 +1,30 @@
+from odoo import models
+
+
+class StockMove(models.Model):
+    _name = "stock.move"
+    _inherit = ["stock.move", "stock.notifier.pos.mixin"]
+
+    def write(self, vals):
+        states_dict = {line.id: line.state for line in self} if "state" in vals else {}
+        res = super().write(vals)
+        if not states_dict:
+            return res
+        for line in self:
+            if states_dict.get(line.id) != line.state:
+                line._notify_pos()
+        return res
+
+    def _action_done(self, cancel_backorder=False):
+        # As stock will be updated once move has updated its state, skip
+        #   notification from quant
+        return super(
+            StockMove, self.with_context(skip_quant_notify_pos=True)
+        )._action_done(cancel_backorder=cancel_backorder)
+
+    def _get_warehouses_to_notify(self):
+        warehouses = super()._get_warehouses_to_notify()
+        warehouses |= self.warehouse_id
+        warehouses |= self.location_id.warehouse_id
+        warehouses |= self.location_dest_id.warehouse_id
+        return warehouses

--- a/pos_stock_available_online/models/stock_notifier_pos_mixin.py
+++ b/pos_stock_available_online/models/stock_notifier_pos_mixin.py
@@ -1,0 +1,51 @@
+from odoo import models
+
+
+class StockNotifierPosMixin(models.AbstractModel):
+    _name = "stock.notifier.pos.mixin"
+    _description = "Stock Notifier POS Mixin"
+
+    def _prepare_pos_message(self):
+        """
+        Return prepared message to send to POS
+        """
+        self.ensure_one()
+        return self.warehouse_id._prepare_vals_for_pos(self.product_id)
+
+    def _skip_notify_pos(self):
+        """
+        Skip notification to POS
+        """
+        return False
+
+    def _get_warehouses_to_notify(self):
+        self.ensure_one()
+        return self.env["stock.warehouse"]
+
+    def _notify_pos(self):
+        """
+        Send notification to POS
+        """
+        pos_session_obj = self.env["pos.session"]
+        for record in self:
+            if record._skip_notify_pos():
+                continue
+            for warehouse in self._get_warehouses_to_notify():
+                configs = pos_session_obj.search(
+                    [
+                        ("state", "=", "opened"),
+                        ("config_id.display_product_quantity", "=", True),
+                        "|",
+                        ("config_id.additional_warehouse_ids", "in", [warehouse.id]),
+                        ("config_id.main_warehouse_id", "=", warehouse.id),
+                        "|",
+                        ("config_id.iface_available_categ_ids", "=", False),
+                        (
+                            "config_id.iface_available_categ_ids",
+                            "in",
+                            [record.product_id.pos_categ_id.id],
+                        ),
+                    ],
+                ).mapped("config_id")
+                if configs:
+                    configs._notify_available_quantity(record._prepare_pos_message())

--- a/pos_stock_available_online/models/stock_quant.py
+++ b/pos_stock_available_online/models/stock_quant.py
@@ -1,47 +1,23 @@
-import logging
-
 from odoo import models
-
-_logger = logging.getLogger(__name__)
 
 
 class StockQuant(models.Model):
-    _inherit = "stock.quant"
-
-    def _prepare_pos_message(self):
-        """
-        Return prepared message to send to POS
-        """
-        self.ensure_one()
-        return self.warehouse_id._prepare_vals_for_pos(self.product_id)
-
-    def _notify_pos(self):
-        """
-        Send notification to POS
-        """
-        pos_session_obj = self.env["pos.session"]
-        for quant in self:
-            warehouse_id = quant.warehouse_id.id
-            configs = pos_session_obj.search(
-                [
-                    ("state", "=", "opened"),
-                    ("config_id.display_product_quantity", "=", True),
-                    "|",
-                    ("config_id.additional_warehouse_ids", "in", [warehouse_id]),
-                    ("config_id.main_warehouse_id", "=", warehouse_id),
-                    "|",
-                    ("config_id.iface_available_categ_ids", "=", False),
-                    (
-                        "config_id.iface_available_categ_ids",
-                        "in",
-                        [quant.product_id.pos_categ_id.id],
-                    ),
-                ],
-            ).mapped("config_id")
-            if configs:
-                configs._notify_available_quantity(quant._prepare_pos_message())
+    _name = "stock.quant"
+    _inherit = ["stock.quant", "stock.notifier.pos.mixin"]
 
     def write(self, vals):
         res = super().write(vals)
         self._notify_pos()
         return res
+
+    def _skip_notify_pos(self):
+        self.ensure_one()
+        return (
+            self.env.context.get("skip_quant_notify_pos", False)
+            or super()._skip_notify_pos()
+        )
+
+    def _get_warehouses_to_notify(self):
+        warehouses = super()._get_warehouses_to_notify()
+        warehouses |= self.warehouse_id
+        return warehouses


### PR DESCRIPTION
Make stock updates not only on quant updates, but also when a stock move changes its state.

This fixes two bugs:

- Stock is not updated when a new incoming move is ready, or when a ready one is cancelled. This triggers notification in both outgoing and incoming warehouses

- Stock is decreased twice because when quant is updated, move is taken in account because it is not yet on 'done' state. This was reported in https://github.com/OCA/pos/issues/1039, but the proposed solution in https://github.com/OCA/pos/pull/1041 was local and only concerned moves from PoS orders

FL-556-4139