### PR TITLE
[16.0][FIX] pos_order_to_sale_order: rpc helper

### DIFF
--- a/pos_order_to_sale_order/static/src/js/CreateOrderPopup.js
+++ b/pos_order_to_sale_order/static/src/js/CreateOrderPopup.js
@@ -43,11 +43,12 @@ odoo.define("point_of_sale.CreateOrderPopup", function (require) {
         async _createSaleOrder(order_state) {
             const current_order = this.env.pos.get_order();
             framework.blockUI();
-            return await this.rpc({
-                model: "sale.order",
-                method: "create_order_from_pos",
-                args: [current_order.export_as_JSON(), order_state],
-            })
+            return await this.env.services
+                .rpc({
+                    model: "sale.order",
+                    method: "create_order_from_pos",
+                    args: [current_order.export_as_JSON(), order_state],
+                })
                 .catch(function (error) {
                     throw error;
                 })


### PR DESCRIPTION
`rpc` attribute used comes from LegacyComponent, that is deprecated and throws an error in some specific cases. Changing it by `this.env.services` works properly in all cases.

This can be reproduced executing this from other component:
```javascript
const create_order = new CreateOrderPopup(props, this.env);
const {sale_order_id} = await create_order._createSaleOrder("draft");
```

FL-556-4346