### PR TITLE
[16.0][FIX] pos_product_multi_barcode: stop finding archived products

### DIFF
--- a/pos_product_multi_barcode/models/product.py
+++ b/pos_product_multi_barcode/models/product.py
@@ -17,5 +17,8 @@ class ProductProduct(models.Model):
 
     def _compute_barcodes_json(self):
         for product in self:
-            barcodes = [barcode for barcode in product.mapped("barcode_ids.name")]
-            product.barcodes_json = json.dumps(barcodes)
+            if product.active:
+                barcodes = [barcode for barcode in product.mapped("barcode_ids.name")]
+                product.barcodes_json = json.dumps(barcodes)
+            else:
+                product.barcodes_json = "[]"


### PR DESCRIPTION
My first contribution to OCA, an easy one I hope:

“pos_product_multi_barcode" is causing archived products to be found when reading their barcodes at the point of sale.