### PR TITLE
[16.0][IMP] pos_order_remove_line: set orderline to quantity before delete

### DIFF
--- a/pos_order_remove_line/static/src/js/orderline.esm.js
+++ b/pos_order_remove_line/static/src/js/orderline.esm.js
@@ -13,6 +13,7 @@ const PosOrderline = (OriginalOrderline) =>
             ev.stopPropagation();
             ev.preventDefault();
             this.selectLine();
+            this.env.pos.numpadMode = "quantity";
             this.trigger("update-selected-orderline", {buffer: null, key: "Backspace"});
         }
     };


### PR DESCRIPTION
Description:

In some cases, like order lines with down payments added by pos_sale, it’s necessary to force the numpad mode to "quantity" for the trash can action button to work. This PR ensures the correct mode is set before triggering deletion, ensuring that it completes correctly.

Cases covered with this improvement:

- Order lines, including down payments added with pos_sale, are now properly deleted without errors.
- Ensures compatibility with other modules that require specific modes when deleting order lines.

Reproduction Steps (in runboat):

1. Create an order in Sales > Orders > Quotation.
2. Open the order from the list in the POS.
3. Apply a down payment.
4. Attempt to delete the line with the trash button: it now deletes as expected.

Solution:

To resolve this issue, we modified the removeLine method in the PosOrderline class to switch to "quantity mode" (this.env.pos.numpadMode = "quantity") before initiating the delete action. This adjustment sets the correct mode, allowing the order line to be deleted without conflicts, even if it's a down payment.

FL-556-4557