### PR TITLE
[16.0][IMP] pos_daily_sales_reports_category_only: this setting is not acti…

### DIFF
--- a/pos_daily_sales_reports_category_only/models/pos_config.py
+++ b/pos_daily_sales_reports_category_only/models/pos_config.py
@@ -8,5 +8,5 @@ class PosConfig(models.Model):
     _inherit = "pos.config"
 
     sales_report_by_category_only = fields.Boolean(
-        string="Sales Report by Category only?", default=True
+        string="Sales Report by Category only?", default=False
     )


### PR DESCRIPTION
**Description:**

When the ` pos_daily_sales_reports_category_only ` module is installed, it automatically enables the **"sales_report_by_category_only"** setting. 

This means that the sales detail reports in the Point of Sale (POS) will, by default, display data grouped only by product category.

However, if the user prefers a more detailed view instead of this categorized display, they must manually uncheck the setting to view sales reports with a higher level of detail.


**Cases Covered with this improvement:**

> The sales detail reports display sales data grouped by individual products, allowing users to access more detailed information when operating the POS without needing to adjust the configuration.


**Solution:**

To address this issue, the following adjustment was implemented:

> The module's configuration was updated so that the **"sales_report_by_category_only"** option is no longer enabled by default upon installation.