### PR TITLE
[16.0][FIX] pos_product_multi_barcode: incoherent data

### DIFF
--- a/pos_product_multi_barcode/static/src/js/db.js
+++ b/pos_product_multi_barcode/static/src/js/db.js
@@ -20,6 +20,9 @@ odoo.define("pos_product_multi_barcode.db", function (require) {
                 var barcodes = JSON.parse(product.barcodes_json);
 
                 barcodes.forEach(function (barcode) {
+                    if (barcode in self.product_by_barcode) {
+                        return;
+                    }
                     self.product_by_barcode[barcode] = product;
                 });
             });


### PR DESCRIPTION
If a `barcode` is already in `product_by_barcode`, do not override it, as [Odoo does with `product_by_id`](https://github.com/OCA/OCB/blob/8b357a8ce22a65a571655b2350cb64ad1f246647/addons/point_of_sale/static/src/js/db.js#L197). This can lead to incoherent data if something changes after product is first loaded and then reloads (if limited loading is enabled), or it is modified in `product_by_id` and not in `product_by_barcode`.

FL-556-4600

FL-556-5129