### PR TITLE
[16.0][FIX] pos_order_to_sale_order: recompute taxes

### DIFF
--- a/pos_order_to_sale_order/models/sale_order.py
+++ b/pos_order_to_sale_order/models/sale_order.py
@@ -34,6 +34,7 @@ class SaleOrder(models.Model):
         sale_order = self.with_context(
             pos_order_lines_data=[x[2] for x in order_data.get("lines", [])]
         ).create(order_vals)
+        sale_order._recompute_taxes()
 
         # Confirm Sale Order
         if action in ["confirmed", "delivered", "invoiced"]:


### PR DESCRIPTION
Recompute `sale.order` taxes, as received ones are the ones from product, without fiscal position mapping applied. Follows https://github.com/OCA/pos/issues/1291

How to reproduce in branch 16.0:
1. Configure a fiscal position that maps an included tax to an excluded one
    ![image](https://github.com/user-attachments/assets/88c50a5d-3b24-4f5d-b543-0a122807708f)
2. Configure a product with included taxes
    ![image](https://github.com/user-attachments/assets/d86fd30a-b84b-41ff-91bd-e502bdd67f15)
3. Add this product to cart in PoS
    ![image](https://github.com/user-attachments/assets/635b7e49-5e5f-481f-9911-22f0423ccd96)
4. Created `sale.order` has different taxes and totals
    ![image](https://github.com/user-attachments/assets/40de658c-7dbd-461e-9b77-7c52e6f2e8f8)


With this change, taxes are recomputed right after sale order creation, so taxes are the same as in PoS:

![image](https://github.com/user-attachments/assets/a7c57b13-e40e-4ba1-ba52-180d6f97f253)

cc @legalsylvain @Jordi-Buitrago @navarrorico

FL-556-5334