### PR TITLE
[FIX] pos_stock_available_online: prevent ensure_one() error, if we write on many items. (for exemple many quants)

### DIFF
--- a/pos_stock_available_online/models/stock_notifier_pos_mixin.py
+++ b/pos_stock_available_online/models/stock_notifier_pos_mixin.py
@@ -23,7 +23,7 @@ class StockNotifierPosMixin(models.AbstractModel):
         for record in self:
             if record._skip_notify_pos():
                 continue
-            for warehouse in self._get_warehouses_to_notify():
+            for warehouse in record._get_warehouses_to_notify():
                 configs = pos_session_obj.search(
                     [
                         ("state", "=", "opened"),


### PR DESCRIPTION
Step to reproduce : 
- install pos_stock_available_online
- install sale_stock

you have an error. see : https://runboat.odoo-community.org/api/v1/builds/be33e0090-c881-4b4e-b0d4-6d8ee903648d/init-log

This is making failing silently the runboat for the time being, on the database with "all modules".
So it is only possible to test modules with "baseonly" option.



```

2025-02-21 14:31:29,551 276 INFO be33e0090-c881-4b4e-b0d4-6d8ee903648d odoo.modules.loading: loading sale_stock/data/sale_order_demo.xml 
2025-02-21 14:31:30,000 276 WARNING be33e0090-c881-4b4e-b0d4-6d8ee903648d odoo.modules.loading: Module sale_stock demo data failed to install, installed without demo data 
Traceback (most recent call last):
  File "/opt/odoo/odoo/models.py", line 5201, in ensure_one
    _id, = self._ids
ValueError: too many values to unpack (expected 1)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/odoo/odoo/tools/convert.py", line 698, in _tag_root
    f(rec)
  File "/opt/odoo/odoo/tools/convert.py", line 333, in _tag_function
    _eval_xml(self, rec, env)
  File "/opt/odoo/odoo/tools/convert.py", line 204, in _eval_xml
    return odoo.api.call_kw(model, method_name, args, kwargs)
  File "/opt/odoo/odoo/api.py", line 468, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/addons/stock/models/stock_quant.py", line 459, in action_apply_inventory
    self._apply_inventory()
  File "/opt/odoo/addons/stock_account/models/stock_quant.py", line 70, in _apply_inventory
    super(StockQuant, inventories)._apply_inventory()
  File "/opt/odoo/addons/stock/models/stock_quant.py", line 780, in _apply_inventory
    self.write({'inventory_quantity': 0, 'user_id': False})
  File "/mnt/data/odoo-addons-dir/pos_stock_available_online/models/stock_quant.py", line 10, in write
    self._notify_pos()
  File "/mnt/data/odoo-addons-dir/pos_stock_available_online/models/stock_notifier_pos_mixin.py", line 26, in _notify_pos
    for warehouse in self._get_warehouses_to_notify():
  File "/mnt/data/odoo-addons-dir/pos_stock_available_online/models/stock_quant.py", line 21, in _get_warehouses_to_notify
    warehouses = super()._get_warehouses_to_notify()
  File "/mnt/data/odoo-addons-dir/pos_stock_available_online/models/stock_notifier_pos_mixin.py", line 15, in _get_warehouses_to_notify
    self.ensure_one()
  File "/opt/odoo/odoo/models.py", line 5204, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: stock.quant(41, 42)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/odoo/modules/loading.py", line 90, in load_demo
    load_data(cr, idref, mode, kind='demo', package=package)
  File "/opt/odoo/odoo/modules/loading.py", line 72, in load_data
    tools.convert_file(cr, package.name, filename, idref, mode, noupdate, kind)
  File "/opt/odoo/odoo/tools/convert.py", line 763, in convert_file
    convert_xml_import(cr, module, fp, idref, mode, noupdate)
  File "/opt/odoo/odoo/tools/convert.py", line 829, in convert_xml_import
    obj.parse(doc.getroot())
  File "/opt/odoo/odoo/tools/convert.py", line 749, in parse
    self._tag_root(de)
  File "/opt/odoo/odoo/tools/convert.py", line 698, in _tag_root
    f(rec)
  File "/opt/odoo/odoo/tools/convert.py", line 711, in _tag_root
    raise ParseError('while parsing %s:%s, somewhere inside\n%s' % (
odoo.tools.convert.ParseError: while parsing /opt/odoo/addons/sale_stock/data/sale_order_demo.xml:174, somewhere inside
<function model="stock.quant" name="action_apply_inventory">
            <function eval="[[('id', 'in', (ref('stock_inventory_7e'),                                             ref('stock_inventory_7f'),                                             ))]]" model="stock.quant" name="search"/>
        </function>

```


