### PR TITLE
[17.0][FW][FIX] pos_order_to_sale_order: recompute taxes

### DIFF
--- a/pos_order_to_sale_order/models/sale_order.py
+++ b/pos_order_to_sale_order/models/sale_order.py
@@ -34,6 +34,7 @@ class SaleOrder(models.Model):
         sale_order = self.with_context(
             pos_order_lines_data=[x[2] for x in order_data.get("lines", [])]
         ).create(order_vals)
+        sale_order._recompute_taxes()
 
         # Confirm Sale Order
         if action in ["confirmed", "delivered", "invoiced"]:


### PR DESCRIPTION
Recompute `sale.order` taxes, as received ones are the ones from product, without fiscal position mapping applied.

FW port of https://github.com/OCA/pos/pull/1318 (see https://github.com/OCA/pos/issues/1291)

cc @legalsylvain 