### PR TITLE
[16.0][IMP] pos_order_to_sale_order: Set default warehouse from session config

### DIFF
--- a/pos_order_to_sale_order/models/sale_order.py
+++ b/pos_order_to_sale_order/models/sale_order.py
@@ -25,6 +25,7 @@ class SaleOrder(models.Model):
             "pricelist_id": order_data["pricelist_id"],
             "fiscal_position_id": order_data["fiscal_position_id"],
             "order_line": order_lines,
+            "warehouse_id": session.config_id.picking_type_id.warehouse_id.id,
         }
 
     @api.model


### PR DESCRIPTION
The default warehouse for POS orders is now automatically set based on  
`session.config_id.picking_type_id.warehouse_id.id`, ensuring correct warehouse assignment.