### PR TITLE
[16.0][IMP] pos_membership_extension: consider membership in shopping cart

### DIFF
--- a/pos_membership_extension/README.rst
+++ b/pos_membership_extension/README.rst
@@ -58,7 +58,8 @@ Usage
 
 * You can see that some products have a new icon that mention
   that the product is not sallable. the icon disappear if you select
-  a customer that belong to one of the membership categories :
+  a customer that belong to one of the membership categories or if the
+  membership product for one of the categories is in the shopping cart :
 
   .. figure:: https://raw.githubusercontent.com/OCA/pos/16.0/pos_membership_extension/static/description/point_of_sale_product_item.png
 
@@ -67,8 +68,8 @@ Usage
 
   .. figure:: https://raw.githubusercontent.com/OCA/pos/16.0/pos_membership_extension/static/description/point_of_sale_popup_product_info.png
 
-* If you select the product with an incorrect customer,
-  you'll see an error Popup :
+* If you select the product with an incorrect customer and without any required
+  membership product in the shopping cart, you'll see an error Popup :
 
   .. figure:: https://raw.githubusercontent.com/OCA/pos/16.0/pos_membership_extension/static/description/point_of_sale_popup_error.png
 

--- a/pos_membership_extension/models/pos_session.py
+++ b/pos_membership_extension/models/pos_session.py
@@ -10,7 +10,11 @@ class PosSession(models.Model):
 
     def _loader_params_product_product(self):
         res = super()._loader_params_product_product()
-        res["search_params"]["fields"] += ["allowed_membership_category_ids"]
+        res["search_params"]["fields"] += [
+            "allowed_membership_category_ids",
+            "membership",
+            "membership_category_id",
+        ]
         return res
 
     def _loader_params_res_partner(self):

--- a/pos_membership_extension/readme/USAGE.rst
+++ b/pos_membership_extension/readme/USAGE.rst
@@ -2,7 +2,8 @@
 
 * You can see that some products have a new icon that mention
   that the product is not sallable. the icon disappear if you select
-  a customer that belong to one of the membership categories :
+  a customer that belong to one of the membership categories or if the
+  membership product for one of the categories is in the shopping cart :
 
   .. figure:: ../static/description/point_of_sale_product_item.png
 
@@ -11,8 +12,8 @@
 
   .. figure:: ../static/description/point_of_sale_popup_product_info.png
 
-* If you select the product with an incorrect customer,
-  you'll see an error Popup :
+* If you select the product with an incorrect customer and without any required
+  membership product in the shopping cart, you'll see an error Popup :
 
   .. figure:: ../static/description/point_of_sale_popup_error.png
 

--- a/pos_membership_extension/static/description/index.html
+++ b/pos_membership_extension/static/description/index.html
@@ -413,7 +413,8 @@ to the documentation of the OCA <tt class="docutils literal">membership_extensio
 </li>
 <li><p class="first">You can see that some products have a new icon that mention
 that the product is not sallable. the icon disappear if you select
-a customer that belong to one of the membership categories :</p>
+a customer that belong to one of the membership categories or if the
+membership product for one of the categories is in the shopping cart :</p>
 <div class="figure">
 <img alt="https://raw.githubusercontent.com/OCA/pos/16.0/pos_membership_extension/static/description/point_of_sale_product_item.png" src="https://raw.githubusercontent.com/OCA/pos/16.0/pos_membership_extension/static/description/point_of_sale_product_item.png" />
 </div>
@@ -424,8 +425,8 @@ allowed for the current product :</p>
 <img alt="https://raw.githubusercontent.com/OCA/pos/16.0/pos_membership_extension/static/description/point_of_sale_popup_product_info.png" src="https://raw.githubusercontent.com/OCA/pos/16.0/pos_membership_extension/static/description/point_of_sale_popup_product_info.png" />
 </div>
 </li>
-<li><p class="first">If you select the product with an incorrect customer,
-you’ll see an error Popup :</p>
+<li><p class="first">If you select the product with an incorrect customer and without any required
+membership product in the shopping cart, you’ll see an error Popup :</p>
 <div class="figure">
 <img alt="https://raw.githubusercontent.com/OCA/pos/16.0/pos_membership_extension/static/description/point_of_sale_popup_error.png" src="https://raw.githubusercontent.com/OCA/pos/16.0/pos_membership_extension/static/description/point_of_sale_popup_error.png" />
 </div>

--- a/pos_membership_extension/static/src/js/ProductItem.js
+++ b/pos_membership_extension/static/src/js/ProductItem.js
@@ -10,7 +10,7 @@ odoo.define("pos_membership_extension.ProductItem", function (require) {
         class OverloadProductItem extends ProductItem {
             get membership_allowed() {
                 var res = this.props.product.get_membership_allowed(
-                    this.env.pos.get_order().partner
+                    this.env.pos.get_order()
                 );
                 return res;
             }

--- a/pos_membership_extension/static/src/js/ProductScreen.js
+++ b/pos_membership_extension/static/src/js/ProductScreen.js
@@ -10,7 +10,7 @@ odoo.define("pos_membership_extension.ProductScreen", function (require) {
         class OverloadProductScreen extends ProductScreen {
             async _getAddProductOptions(product) {
                 var self = this;
-                if (!product.get_membership_allowed(this.env.pos.get_order().partner)) {
+                if (!product.get_membership_allowed(this.env.pos.get_order())) {
                     await this.showPopup("ErrorPopup", {
                         title: self.env._t("Incorrect Membership"),
                         body: self.env._t(

--- a/pos_membership_extension/static/src/js/models.js
+++ b/pos_membership_extension/static/src/js/models.js
@@ -1,7 +1,7 @@
 odoo.define("pos_membership_extension.models", function (require) {
     "use strict";
 
-    const {Order, Product} = require("point_of_sale.models");
+    const {Order, Orderline, Product} = require("point_of_sale.models");
 
     var core = require("web.core");
 
@@ -15,24 +15,30 @@ odoo.define("pos_membership_extension.models", function (require) {
             /**
              * Return if it's allowed to sell the product to the partner.
              *
-             * @param {partner} partner to test. (can be undefined)
+             * @param {Order} order to test.
              * @returns {Boolean} True if the sell is allowed, false otherwise.
              */
-            get_membership_allowed(partner) {
+            get_membership_allowed(order) {
                 // No categories means no restriction
                 if (this.allowed_membership_category_ids.length === 0) {
                     return true;
                 }
-                // If categories are set, but no partner, sell is forbidden in any case
-                if (!partner) {
-                    return false;
-                }
-                var common_categories = this.allowed_membership_category_ids.filter(
-                    function (categ) {
-                        return partner.membership_category_ids.indexOf(categ) !== -1;
+                const partner = order.partner;
+                // Checks that the partner has a membership category in common with those allowed or
+                // that one of the corresponding membership products is in the order lines
+                return this.allowed_membership_category_ids.some((categ) => {
+                    if (partner && partner.membership_category_ids.includes(categ)) {
+                        return true;
                     }
-                );
-                return common_categories.length !== 0;
+
+                    return order.orderlines.some(
+                        (orderline) =>
+                            orderline.product.membership_category_id[0] === categ &&
+                            ("partner_for_membership" in orderline
+                                ? orderline.partner_for_membership === partner
+                                : true)
+                    );
+                });
             }
         };
     Registries.Model.extend(Product, OverloadProduct);
@@ -40,20 +46,17 @@ odoo.define("pos_membership_extension.models", function (require) {
     const OverloadOrder = (OriginalOrder) =>
         class extends OriginalOrder {
             /**
-             * Overloaded function.
-             * Check if the product of the order lines are allowed by the
-             * new selected partner.
+             * Check if the products of the order lines are allowed.
              * If not, remove according lines and raise a PopUp Error to
              * inform the cashier of the removal.
-             * @param {partner} partner to set to the order. (can be undefined)
-             * @returns {Boolean} In any case, return the result of the super function.
              */
-            set_partner(partner) {
+            _remove_non_allowed_orderlines() {
+                var self = this;
                 var bad_product_list = [];
                 var i = this.orderlines.length;
                 while (i--) {
                     var orderline = this.orderlines[i];
-                    if (!orderline.product.get_membership_allowed(partner)) {
+                    if (!orderline.product.get_membership_allowed(self)) {
                         bad_product_list.push(orderline.product.display_name);
                         this.orderlines.splice(i, 1);
                     }
@@ -67,10 +70,46 @@ odoo.define("pos_membership_extension.models", function (require) {
                         ),
                     });
                 }
+            }
 
-                return super.set_partner(...arguments);
+            /**
+             * Overloaded function.
+             * @param {Orderline} line - The order line to be removed.
+             */
+            remove_orderline(line) {
+                super.remove_orderline(line);
+                if (line.product.membership) {
+                    this._remove_non_allowed_orderlines();
+                    this.select_orderline(this.get_last_orderline());
+                }
+            }
+
+            /**
+             * Overloaded function.
+             * @param {partner} partner to set to the order. (can be undefined)
+             */
+            set_partner(partner) {
+                super.set_partner(partner);
+                this._remove_non_allowed_orderlines();
             }
         };
-
     Registries.Model.extend(Order, OverloadOrder);
+
+    const OverloadOrderline = (OriginalOrderline) => {
+        // Check if the original Orderline model already has
+        // the set_delegated_member method. This is the case if the
+        // pos_membership_delegated_partner module is installed.
+        if (!("set_delegated_member" in OriginalOrderline.prototype)) {
+            return OriginalOrderline;
+        }
+
+        // If the method exists, return a class that extends the original.
+        return class extends OriginalOrderline {
+            set_delegated_member(partner) {
+                super.set_delegated_member(partner);
+                this.order._remove_non_allowed_orderlines();
+            }
+        };
+    };
+    Registries.Model.extend(Orderline, OverloadOrderline);
 });


### PR DESCRIPTION
Allow the sale of a product requiring membership if the membership product is in the shopping cart, even if the customer is not yet a member