### PR TITLE
[16.0][IMP]pos_order_to_sale_order: Allow add the commitment date.

### DIFF
--- a/pos_order_to_sale_order/README.rst
+++ b/pos_order_to_sale_order/README.rst
@@ -117,6 +117,10 @@ Contributors
 
 * Sylvain LE GAL (https://www.twitter.com/legalsylvain)
 
+* `Binhex <https://binhex.cloud>`_:
+
+  * Adasat Torres de León <a.torres@binhex.cloud>
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/pos_order_to_sale_order/__manifest__.py
+++ b/pos_order_to_sale_order/__manifest__.py
@@ -15,11 +15,9 @@
     "data": ["views/view_res_config_settings.xml"],
     "assets": {
         "point_of_sale.assets": [
-            "pos_order_to_sale_order/static/src/css/pos.css",
-            "pos_order_to_sale_order/static/src/js/CreateOrderButton.js",
-            "pos_order_to_sale_order/static/src/js/CreateOrderPopup.js",
-            "pos_order_to_sale_order/static/src/xml/CreateOrderButton.xml",
-            "pos_order_to_sale_order/static/src/xml/CreateOrderPopup.xml",
+            "pos_order_to_sale_order/static/src/css/**.css",
+            "pos_order_to_sale_order/static/src/xml/**.xml",
+            "pos_order_to_sale_order/static/src/js/**.js",
         ],
         "web.assets_tests": [
             "pos_order_to_sale_order/static/tests/**/*.js",

--- a/pos_order_to_sale_order/models/pos_config.py
+++ b/pos_order_to_sale_order/models/pos_config.py
@@ -47,6 +47,13 @@ class PosConfig(models.Model):
         " Only invoice payment process will be possible.",
     )
 
+    iface_sale_order_allow_commitment_date = fields.Boolean(
+        string="Allow Add Commitment Date",
+        default=True,
+        help="If checked, the cashier will have the possibility to add"
+        " a commitment date on the sale order.",
+    )
+
     @api.depends(
         "iface_create_draft_sale_order",
         "iface_create_confirmed_sale_order",

--- a/pos_order_to_sale_order/models/res_config_settings.py
+++ b/pos_order_to_sale_order/models/res_config_settings.py
@@ -23,3 +23,7 @@ class ResConfigSettings(models.TransientModel):
     pos_iface_create_invoiced_sale_order = fields.Boolean(
         related="pos_config_id.iface_create_invoiced_sale_order", readonly=False
     )
+
+    iface_sale_order_allow_commitment_date = fields.Boolean(
+        related="pos_config_id.iface_sale_order_allow_commitment_date", readonly=False
+    )

--- a/pos_order_to_sale_order/models/sale_order.py
+++ b/pos_order_to_sale_order/models/sale_order.py
@@ -2,6 +2,8 @@
 # @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from dateutil import parser as dateutil_parser
+
 from odoo import Command, _, api, models
 
 
@@ -17,6 +19,11 @@ class SaleOrder(models.Model):
             Command.create(SaleOrderLine._prepare_from_pos(sequence, line_data[2]))
             for sequence, line_data in enumerate(order_data["lines"], start=1)
         ]
+        commitment_date = order_data.get("commitment_date", False)
+        if commitment_date:
+            commitment_date = dateutil_parser.parse(commitment_date).replace(
+                tzinfo=None
+            )
         return {
             "partner_id": order_data["partner_id"],
             "origin": _("Point of Sale %s") % (session.name),
@@ -24,6 +31,7 @@ class SaleOrder(models.Model):
             "user_id": order_data["user_id"],
             "pricelist_id": order_data["pricelist_id"],
             "fiscal_position_id": order_data["fiscal_position_id"],
+            "commitment_date": commitment_date,
             "order_line": order_lines,
         }
 

--- a/pos_order_to_sale_order/readme/CONTRIBUTORS.rst
+++ b/pos_order_to_sale_order/readme/CONTRIBUTORS.rst
@@ -1,1 +1,5 @@
 * Sylvain LE GAL (https://www.twitter.com/legalsylvain)
+
+* `Binhex <https://binhex.cloud>`_:
+
+  * Adasat Torres de León <a.torres@binhex.cloud>

--- a/pos_order_to_sale_order/static/description/index.html
+++ b/pos_order_to_sale_order/static/description/index.html
@@ -464,6 +464,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#toc-entry-7">Contributors</a></h2>
 <ul class="simple">
 <li>Sylvain LE GAL (<a class="reference external" href="https://www.twitter.com/legalsylvain">https://www.twitter.com/legalsylvain</a>)</li>
+<li><a class="reference external" href="https://binhex.cloud">Binhex</a>:<ul>
+<li>Adasat Torres de León &lt;<a class="reference external" href="mailto:a.torres&#64;binhex.cloud">a.torres&#64;binhex.cloud</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/pos_order_to_sale_order/static/src/js/CreateOrderPopup.js
+++ b/pos_order_to_sale_order/static/src/js/CreateOrderPopup.js
@@ -4,11 +4,18 @@ odoo.define("point_of_sale.CreateOrderPopup", function (require) {
     const AbstractAwaitablePopup = require("point_of_sale.AbstractAwaitablePopup");
     const Registries = require("point_of_sale.Registries");
     const framework = require("web.framework");
-
     class CreateOrderPopup extends AbstractAwaitablePopup {
         setup() {
             super.setup();
             this.createOrderClicked = false;
+        }
+
+        get currentOrder() {
+            return this.env.pos.get_order();
+        }
+
+        async updateCommitmentDate(ev) {
+            await this.currentOrder.set_commitment_date(ev.target.value);
         }
 
         async createDraftSaleOrder() {
@@ -30,10 +37,8 @@ odoo.define("point_of_sale.CreateOrderPopup", function (require) {
         async _actionCreateSaleOrder(order_state) {
             // Create Sale Order
             await this._createSaleOrder(order_state);
-
             // Delete current order
-            const current_order = this.env.pos.get_order();
-            this.env.pos.removeOrder(current_order);
+            this.env.pos.removeOrder(this.currentOrder);
             this.env.pos.add_new_order();
 
             // Close popup
@@ -41,13 +46,12 @@ odoo.define("point_of_sale.CreateOrderPopup", function (require) {
         }
 
         async _createSaleOrder(order_state) {
-            const current_order = this.env.pos.get_order();
             framework.blockUI();
             return await this.env.services
                 .rpc({
                     model: "sale.order",
                     method: "create_order_from_pos",
-                    args: [current_order.export_as_JSON(), order_state],
+                    args: [this.currentOrder.export_as_JSON(), order_state],
                 })
                 .catch(function (error) {
                     throw error;

--- a/pos_order_to_sale_order/static/src/js/models.esm.js
+++ b/pos_order_to_sale_order/static/src/js/models.esm.js
@@ -1,0 +1,35 @@
+/** @odoo-module **/
+
+import {Order} from "point_of_sale.models";
+import Registries from "point_of_sale.Registries";
+
+const PosOrderToSaleOrderCommitmentDate = (OriginalOrder) =>
+    class extends OriginalOrder {
+        constructor() {
+            super(...arguments);
+            this.commitment_date = false;
+        }
+        get_commitment_date() {
+            return this.commitment_date;
+        }
+        set_commitment_date(commitment_date) {
+            if (!commitment_date) {
+                this.commitment_date = false;
+            } else {
+                this.commitment_date = new Date(commitment_date).toISOString();
+            }
+        }
+        export_as_JSON() {
+            const result = super.export_as_JSON(...arguments);
+            result.commitment_date = this.get_commitment_date();
+            return result;
+        }
+        init_from_JSON(json) {
+            super.init_from_JSON(...arguments);
+            this.set_commitment_date(json.commitment_date || false);
+        }
+    };
+
+Registries.Model.extend(Order, PosOrderToSaleOrderCommitmentDate);
+
+export default PosOrderToSaleOrderCommitmentDate;

--- a/pos_order_to_sale_order/static/src/xml/CreateOrderPopup.xml
+++ b/pos_order_to_sale_order/static/src/xml/CreateOrderPopup.xml
@@ -1,17 +1,33 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates id="template" xml:space="preserve">
-
     <t t-name="CreateOrderPopup" owl="1">
         <div class="popup popup-create-sale-order">
-
             <header>
                 <div class="title">Create Order</div>
             </header>
-
             <main class="body">
-
                 <table>
                     <tbody>
+                        <tr
+                            t-if="env.pos.config.iface_sale_order_allow_commitment_date"
+                        >
+                            <td>
+                                <div class="row">
+                                    <label
+                                        class="col-sm-2 col-form-label"
+                                        for="commitment_date"
+                                    >
+                                        Commitment Date
+                                    </label>
+                                    <input
+                                        class="input col-sm-10"
+                                        type="datetime-local"
+                                        t-on-change="updateCommitmentDate"
+                                        name="commitment_date"
+                                    />
+                                </div>
+                            </td>
+                        </tr>
                         <tr t-if="env.pos.config.iface_create_draft_sale_order">
                             <td>
                                 <div
@@ -25,7 +41,6 @@
                                 </div>
                             </td>
                         </tr>
-
                         <tr t-if="env.pos.config.iface_create_confirmed_sale_order">
                             <td>
                                 <div
@@ -39,7 +54,6 @@
                                 </div>
                             </td>
                         </tr>
-
                         <tr t-if="env.pos.config.iface_create_delivered_sale_order">
                             <td>
                                 <div
@@ -54,7 +68,6 @@
                                 </div>
                             </td>
                         </tr>
-
                         <tr t-if="env.pos.config.iface_create_invoiced_sale_order">
                             <td>
                                 <div
@@ -69,18 +82,13 @@
                                     <span>Create Invoiced Sale Order</span>
                                 </div>
                             </td>
-
                         </tr>
                     </tbody>
                 </table>
-
             </main>
-
             <footer class="footer">
                 <div class="button" t-on-click="cancel">Discard</div>
             </footer>
-
         </div>
     </t>
-
 </templates>

--- a/pos_order_to_sale_order/static/tests/tours/PosOrderToSaleOrderTour.esm.js
+++ b/pos_order_to_sale_order/static/tests/tours/PosOrderToSaleOrderTour.esm.js
@@ -28,6 +28,7 @@ ProductScreen.do.clickPartnerButton();
 ProductScreen.do.clickCustomer("Addison Olson");
 
 PosOrderToSaleOrder.do.clickCreateOrderButton();
+PosOrderToSaleOrder.do.addCommitmentDate();
 PosOrderToSaleOrder.do.clickCreateInvoicedOrderButton();
 
 ProductScreen.check.isShown();

--- a/pos_order_to_sale_order/static/tests/tours/helpers/PosOrderToSaleOrderMethods.esm.js
+++ b/pos_order_to_sale_order/static/tests/tours/helpers/PosOrderToSaleOrderMethods.esm.js
@@ -32,6 +32,19 @@ class DoExt extends Do {
             },
         ];
     }
+    addCommitmentDate() {
+        return [
+            {
+                content: "Add Commitment Date",
+                trigger: ".popup-create-sale-order input[name='commitment_date']",
+                run: () => {
+                    this.trigger("input", {
+                        target: {value: "2024-01-01T16:00:00"},
+                    });
+                },
+            },
+        ];
+    }
 }
 
 const methods = createTourMethods("PosOrderToSaleOrder", DoExt);

--- a/pos_order_to_sale_order/tests/__init__.py
+++ b/pos_order_to_sale_order/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_module
+from . import test_sale_order

--- a/pos_order_to_sale_order/tests/test_module.py
+++ b/pos_order_to_sale_order/tests/test_module.py
@@ -62,3 +62,10 @@ class TestUi(TestPointOfSaleHttpCommon):
             order.order_line[1].name,
             "'Product Note' must not contains in sale order line description",
         )
+        self.assertTrue(
+            order.commitment_date,
+        )
+        self.assertEqual(
+            order.commitment_date.strftime("%Y-%m-%d %H:%M:%S"),
+            "2024-01-01 16:00:00",
+        )

--- a/pos_order_to_sale_order/tests/test_sale_order.py
+++ b/pos_order_to_sale_order/tests/test_sale_order.py
@@ -1,0 +1,89 @@
+# Copyright Binhex - Adasat Torres de Leon
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from datetime import datetime
+
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSaleOrder(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env.ref("base.res_partner_1")
+        cls.user = cls.env.ref("base.user_admin")
+        cls.product = cls.env.ref("product.product_product_4")
+        cls.pos_config = cls.env.ref("point_of_sale.pos_config_main")
+        cls.pos_session = cls.env["pos.session"].create(
+            {"config_id": cls.pos_config.id, "user_id": cls.user.id}
+        )
+
+    def test_create_order_from_pos(self):
+        order_data = {
+            "pos_session_id": self.pos_session.id,
+            "partner_id": self.partner.id,
+            "name": "Test Ref",
+            "user_id": self.user.id,
+            "pricelist_id": self.env.ref("product.list0").id,
+            "fiscal_position_id": False,
+            "commitment_date": "2026-02-28T17:27:00.000Z",
+            "lines": [
+                (
+                    0,
+                    0,
+                    {
+                        "product_id": self.product.id,
+                        "qty": 1,
+                        "discount": 0,
+                        "price_unit": 10.0,
+                        "tax_ids": False,
+                    },
+                )
+            ],
+        }
+        result = self.env["sale.order"].create_order_from_pos(
+            order_data, action="draft"
+        )
+        self.assertIn("sale_order_id", result)
+        sale_order = self.env["sale.order"].browse(result["sale_order_id"])
+        self.assertEqual(sale_order.partner_id, self.partner)
+        self.assertEqual(sale_order.origin, "Point of Sale %s" % self.pos_session.name)
+        self.assertEqual(sale_order.client_order_ref, "Test Ref")
+        self.assertEqual(sale_order.user_id, self.user)
+        self.assertEqual(sale_order.pricelist_id, self.env.ref("product.list0"))
+        self.assertFalse(sale_order.fiscal_position_id)
+        self.assertEqual(sale_order.state, "draft")
+        self.assertEqual(len(sale_order.order_line), 1)
+        self.assertEqual(sale_order.order_line.product_id, self.product)
+        self.assertEqual(sale_order.order_line.product_uom_qty, 1)
+        self.assertEqual(sale_order.order_line.price_unit, 10.0)
+        self.assertEqual(sale_order.commitment_date, datetime(2026, 2, 28, 17, 27, 0))
+
+    def test_create_order_from_pos_without_commitment_date(self):
+        """Verifica que commitment_date es opcional"""
+        order_data = {
+            "pos_session_id": self.pos_session.id,
+            "partner_id": self.partner.id,
+            "name": "Test Ref 2",
+            "user_id": self.user.id,
+            "pricelist_id": self.env.ref("product.list0").id,
+            "fiscal_position_id": False,
+            "lines": [
+                (
+                    0,
+                    0,
+                    {
+                        "product_id": self.product.id,
+                        "qty": 1,
+                        "discount": 0,
+                        "price_unit": 10.0,
+                        "tax_ids": False,
+                    },
+                )
+            ],
+        }
+        result = self.env["sale.order"].create_order_from_pos(
+            order_data, action="draft"
+        )
+        sale_order = self.env["sale.order"].browse(result["sale_order_id"])
+        self.assertFalse(sale_order.commitment_date)

--- a/pos_order_to_sale_order/views/view_res_config_settings.xml
+++ b/pos_order_to_sale_order/views/view_res_config_settings.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-
     <record id="view_res_config_settings_form" model="ir.ui.view">
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="point_of_sale.res_config_settings_view_form" />
         <field name="arch" type="xml">
-
             <xpath expr="//div[@id='pos_technical_section']" position="after">
-
                 <h2 name="create_sale_order">Sale Order Creation</h2>
                 <div class="row mt16 o_settings_container">
                     <div class="col-12 col-lg-6 o_setting_box">
@@ -18,7 +15,6 @@
                             <label for="pos_iface_create_draft_sale_order" />
                         </div>
                     </div>
-
                     <div class="col-12 col-lg-6 o_setting_box">
                         <div class="o_setting_left_pane">
                             <field name="pos_iface_create_confirmed_sale_order" />
@@ -27,7 +23,6 @@
                             <label for="pos_iface_create_confirmed_sale_order" />
                         </div>
                     </div>
-
                     <div class="col-12 col-lg-6 o_setting_box">
                         <div class="o_setting_left_pane">
                             <field name="pos_iface_create_delivered_sale_order" />
@@ -36,13 +31,20 @@
                             <label for="pos_iface_create_delivered_sale_order" />
                         </div>
                     </div>
-
                     <div class="col-12 col-lg-6 o_setting_box">
                         <div class="o_setting_left_pane">
                             <field name="pos_iface_create_invoiced_sale_order" />
                         </div>
                         <div class="o_setting_right_pane">
                             <label for="pos_iface_create_invoiced_sale_order" />
+                        </div>
+                    </div>
+                    <div class="col-12 col-lg-6 o_setting_box">
+                        <div class="o_setting_left_pane">
+                            <field name="iface_sale_order_allow_commitment_date" />
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="iface_sale_order_allow_commitment_date" />
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
This add-on allows you to add the commitment date to orders.  
I've included a reference to the previous PR to maintain continuity of the discussion #1360 .