### PR TITLE
[16.0][FIX] pos_payment_change: Change of payment should force the session

### DIFF
--- a/pos_payment_change/models/pos_order.py
+++ b/pos_payment_change/models/pos_order.py
@@ -53,7 +53,9 @@ class PosOrder(models.Model):
         elif self.config_id.payment_change_policy == "refund":
             # Refund order and mark it as paid
             # with same payment method as the original one
-            refund_result = self.refund()
+            refund_result = self.with_context(
+                force_session_id=self.session_id.id
+            ).refund()
             refund_order = self.browse(refund_result["res_id"])
             for payment in self.payment_ids:
                 refund_order.add_payment(
@@ -99,3 +101,11 @@ class PosOrder(models.Model):
                     session=", ".join(closed_orders.mapped("session_id.name")),
                 )
             )
+
+    def _prepare_refund_values(self, current_session):
+        session = current_session
+        if "force_session_id" in self.env.context:
+            session = self.env["pos.session"].browse(
+                self.env.context.get("force_session_id")
+            )
+        return super()._prepare_refund_values(session)

--- a/pos_payment_change/tests/test_module.py
+++ b/pos_payment_change/tests/test_module.py
@@ -218,3 +218,20 @@ class TestModule(TransactionCase):
             }
         )
         wizard.button_change_payment()
+
+    def test_05_payment_change_closed_orders_new_session(self):
+        self.pos_config.payment_change_policy = "refund"
+
+        self._initialize_journals_open_session()
+        # Make a sale with 35 in cash journal and 65 in check
+        order = self._sale(self.cash_payment_method, 35, self.bank_payment_method, 65)
+
+        self.session.rescue = True
+        self.pos_config._compute_current_session()
+        # We need to force the compute, as it is does not depend on rescue
+        self.pos_config.open_ui()
+        self.assertNotEqual(self.session, self.pos_config.current_session_id)
+        self._change_payment(
+            order, self.cash_payment_method, 10, self.bank_payment_method, 90
+        )
+        self.assertEqual(self.session, order.payment_ids.session_id)


### PR DESCRIPTION
Otherwise, something weird might happen. For example, if we have a rescue session and we try to do the change, the refund is assigned to another session, no the rescue one.