### PR TITLE
[16.0][IMP]pos_access_right: compatibility with multi-employee option.

### DIFF
--- a/pos_access_right/README.rst
+++ b/pos_access_right/README.rst
@@ -36,6 +36,8 @@ This module extends Odoo Point Of Sale features, restricting possibility to cash
 * **PoS - Many Orders**: The cashier can many orders at the same time;
 * **PoS - Delete Order**: The cashier can not delete a full order;
 
+This addon is compatible with the multi-employee per session option.
+
 **Table of contents**
 
 .. contents::
@@ -46,12 +48,17 @@ Configuration
 
 Once installed, you have to give correct access right to your cashiers.
 
+
 Usage
 =====
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
    :target: https://runbot.odoo-community.org/runbot/184/9.0
+
+When the multi-employee per session option is enabled in the Point of Sale configuration,
+the allowed employees will use the permissions of their linked user's groups.
+If they don't have a linked user, they will use the permissions of the logged-in user.
 
 Bug Tracker
 ===========

--- a/pos_access_right/__manifest__.py
+++ b/pos_access_right/__manifest__.py
@@ -10,7 +10,7 @@
     "author": "La Louve, GRAP, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/pos",
     "license": "AGPL-3",
-    "depends": ["point_of_sale"],
+    "depends": ["point_of_sale", "pos_hr"],
     "demo": ["demo/res_groups.xml"],
     "data": [
         "security/res_groups.xml",

--- a/pos_access_right/models/pos_session.py
+++ b/pos_access_right/models/pos_session.py
@@ -20,3 +20,23 @@ class PosSession(models.Model):
                 hasGroupDeleteOrder=config.group_delete_order_id in groups,
             )
         return user_vals
+
+    def _get_pos_ui_hr_employee(self, params):
+        employee_vals = super()._get_pos_ui_hr_employee(params)
+        if employee_vals:
+            for employee in employee_vals:
+                user_id = employee.get("user_id", False)
+                if not user_id:
+                    user_id = self.env.user.id
+                user = self.env["res.users"].browse(user_id)
+                groups = user.groups_id
+                config = self.config_id
+                employee.update(
+                    hasGroupPayment=config.group_payment_id in groups,
+                    hasGroupDiscount=config.group_discount_id in groups,
+                    hasGroupNegativeQty=config.group_negative_qty_id in groups,
+                    hasGroupPriceControl=config.group_change_unit_price_id in groups,
+                    hasGroupMultiOrder=config.group_multi_order_id in groups,
+                    hasGroupDeleteOrder=config.group_delete_order_id in groups,
+                )
+        return employee_vals

--- a/pos_access_right/readme/CONFIGURE.rst
+++ b/pos_access_right/readme/CONFIGURE.rst
@@ -1,1 +1,2 @@
 Once installed, you have to give correct access right to your cashiers.
+

--- a/pos_access_right/readme/DESCRIPTION.rst
+++ b/pos_access_right/readme/DESCRIPTION.rst
@@ -5,3 +5,5 @@ This module extends Odoo Point Of Sale features, restricting possibility to cash
 * **PoS - Change Unit Price**: The cashier can change the unit price of a product in Point Of Sale;
 * **PoS - Many Orders**: The cashier can many orders at the same time;
 * **PoS - Delete Order**: The cashier can not delete a full order;
+
+This addon is compatible with the multi-employee per session option.

--- a/pos_access_right/readme/USAGE.rst
+++ b/pos_access_right/readme/USAGE.rst
@@ -1,3 +1,7 @@
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
    :target: https://runbot.odoo-community.org/runbot/184/9.0
+
+When the multi-employee per session option is enabled in the Point of Sale configuration,
+the allowed employees will use the permissions of their linked user's groups.
+If they don't have a linked user, they will use the permissions of the logged-in user.

--- a/pos_access_right/static/description/index.html
+++ b/pos_access_right/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -377,6 +378,7 @@ ul.auto-toc {
 <li><strong>PoS - Many Orders</strong>: The cashier can many orders at the same time;</li>
 <li><strong>PoS - Delete Order</strong>: The cashier can not delete a full order;</li>
 </ul>
+<p>This addon is compatible with the multi-employee per session option.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -397,7 +399,12 @@ ul.auto-toc {
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
-<a class="reference external image-reference" href="https://runbot.odoo-community.org/runbot/184/9.0"><img alt="Try me on Runbot" src="https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas" /></a>
+<a class="reference external image-reference" href="https://runbot.odoo-community.org/runbot/184/9.0">
+<img alt="Try me on Runbot" src="https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas" />
+</a>
+<p>When the multi-employee per session option is enabled in the Point of Sale configuration,
+the allowed employees will use the permissions of their linked user’s groups.
+If they don’t have a linked user, they will use the permissions of the logged-in user.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
@@ -427,7 +434,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/pos_access_right/static/src/js/ActionpadWidget.js
+++ b/pos_access_right/static/src/js/ActionpadWidget.js
@@ -7,6 +7,8 @@ odoo.define("pos_access_right.ActionpadWidget", function (require) {
     const PosActionpadWidget = (OriginalActionpadWidget) =>
         class extends OriginalActionpadWidget {
             get hasPaymentControlRights() {
+                if (this.env.pos.config.module_pos_hr)
+                    return this.env.pos.cashier.hasGroupPayment;
                 return this.env.pos.user.hasGroupPayment;
             }
         };

--- a/pos_access_right/static/src/js/NumpadWidget.js
+++ b/pos_access_right/static/src/js/NumpadWidget.js
@@ -9,16 +9,22 @@ odoo.define("pos_access_right.NumpadWidget", function (require) {
             get hasManualDiscount() {
                 const res = super.hasManualDiscount;
                 if (res) {
+                    if (this.env.pos.config.module_pos_hr)
+                        return this.env.pos.cashier.hasGroupDiscount;
                     return this.env.pos.user.hasGroupDiscount;
                 }
                 return res;
             }
             get hasMinusControlRights() {
+                if (this.env.pos.config.module_pos_hr)
+                    return this.env.pos.cashier.hasGroupNegativeQty;
                 return this.env.pos.user.hasGroupNegativeQty;
             }
             get hasPriceControlRights() {
                 const res = super.hasPriceControlRights;
                 if (res) {
+                    if (this.env.pos.config.module_pos_hr)
+                        return this.env.pos.cashier.hasGroupPriceControl;
                     return this.env.pos.user.hasGroupPriceControl;
                 }
                 return res;

--- a/pos_access_right/static/src/js/TicketScreen.js
+++ b/pos_access_right/static/src/js/TicketScreen.js
@@ -7,13 +7,22 @@ odoo.define("pos_access_right.TicketScreen", function (require) {
     const PosTicketScreen = (OriginalTicketScreen) =>
         class extends OriginalTicketScreen {
             get hasNewOrdersControlRights() {
+                if (this.env.pos.config.module_pos_hr)
+                    return this.env.pos.cashier.hasGroupMultiOrder;
                 return this.env.pos.user.hasGroupMultiOrder;
             }
 
             async deleteOrder(order) {
-                if (this.env.pos.user.hasGroupDeleteOrder) {
+                if (
+                    this.env.pos.config.module_pos_hr &&
+                    this.env.pos.cashier.hasGroupDeleteOrder
+                )
                     return super.deleteOrder(order);
-                }
+                else if (
+                    !this.env.pos.config.module_pos_hr &&
+                    this.env.pos.user.hasGroupDeleteOrder
+                )
+                    return super.deleteOrder(order);
                 return false;
             }
         };


### PR DESCRIPTION
This implementation aims to enable the option to use the permissions of the user linked to the employee when the option to use multiple employees per session is active. If the employee has no related user, the permissions of the user logged into the backend are used instead.