### PR TITLE
[16.0][FIX]pos_access_right: change deleteOrder to _onDeleteOrder

### DIFF
--- a/pos_access_right/static/src/js/TicketScreen.js
+++ b/pos_access_right/static/src/js/TicketScreen.js
@@ -10,11 +10,11 @@ odoo.define("pos_access_right.TicketScreen", function (require) {
                 return this.env.pos.user.hasGroupMultiOrder;
             }
 
-            async deleteOrder(order) {
-                if (this.env.pos.user.hasGroupDeleteOrder) {
-                    return super.deleteOrder(order);
+            async _onDeleteOrder({detail: order}) {
+                if (!this.env.pos.user.hasGroupDeleteOrder) {
+                    return;
                 }
-                return false;
+                return super._onDeleteOrder({detail: order});
             }
         };
 


### PR DESCRIPTION
I've noticed that the `deleteOrder` method in the `TicketScreen` component is no longer used in Odoo 16.0 — it has been renamed to `_onDeleteOrder`. https://github.com/odoo/odoo/blob/bfeab2559f9a0df8790322bac0fe3b2a09d3f9c9/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js#L108
After checking on Runboat, I also found that the permission intended to disable order deletion is currently not functioning as expected.
To improve maintainability and extensibility, I’ve restructured the code within the `_onDeleteOrder` method, making it easier to inherit and override in custom modules.