### PR TITLE
[16.0][FIX] pos_membership_extension: add dependency

### DIFF
--- a/pos_membership_extension/__manifest__.py
+++ b/pos_membership_extension/__manifest__.py
@@ -12,7 +12,7 @@
     "author": "GRAP,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/pos",
     "license": "AGPL-3",
-    "depends": ["point_of_sale", "membership_extension"],
+    "depends": ["pos_membership", "membership_extension"],
     "assets": {
         "point_of_sale.assets": [
             "pos_membership_extension/static/src/css/pos.css",


### PR DESCRIPTION
Without the pos_membership module, it is possible to sell a membership without creating an invoice and without selecting a customer.