### PR TITLE
[14.0][IMP] pos_payment_change: Datetime management

### DIFF
--- a/pos_payment_change/models/pos_order.py
+++ b/pos_payment_change/models/pos_order.py
@@ -63,7 +63,7 @@ class PosOrder(models.Model):
                         "pos_order_id": refund_order.id,
                         "payment_method_id": payment.payment_method_id.id,
                         "amount": -payment.amount,
-                        "payment_date": fields.Date.context_today(self),
+                        "payment_date": self._get_datetime_payment_change_policy(),
                     }
                 )
 
@@ -71,7 +71,12 @@ class PosOrder(models.Model):
 
             # Resale order and mark it as paid
             # with the new payment
-            resale_order = self.copy(default={"pos_reference": self.pos_reference})
+            resale_order = self.copy(
+                default={
+                    "pos_reference": self.pos_reference,
+                    "date_order": self._get_datetime_payment_change_policy(),
+                }
+            )
             for line in payment_lines:
                 line.update({"pos_order_id": resale_order.id})
                 resale_order.add_payment(line)
@@ -101,3 +106,9 @@ class PosOrder(models.Model):
                     )
                 )
             )
+
+    def _get_datetime_payment_change_policy(self):
+        if self.config_id.payment_change_policy == "update":
+            return self.date_order
+        else:
+            return fields.Datetime.now()

--- a/pos_payment_change/wizards/pos_payment_change_wizard.py
+++ b/pos_payment_change/wizards/pos_payment_change_wizard.py
@@ -88,7 +88,7 @@ class PosPaymentChangeWizard(models.TransientModel):
                 "pos_order_id": order.id,
                 "payment_method_id": line.new_payment_method_id.id,
                 "amount": line.amount,
-                "payment_date": fields.Date.context_today(self),
+                "payment_date": order._get_datetime_payment_change_policy(),
             }
             for line in self.new_line_ids
         ]


### PR DESCRIPTION
I found that order/payment date had some strange behavior when modifying a payment, see #1325 

Also fix a bug where the resale order was not at the same time as the refund order in case of refund policy.

In case of update policy keep payment_date the same
In case of refund policy use current datetime for refund/resale order and payments