### PR TITLE
[14.0][IMP] pos_order_to_sale_order: Improvement for the ability to use the result of sales order creation after inheritance

### DIFF
--- a/pos_order_to_sale_order/static/src/js/CreateOrderPopup.js
+++ b/pos_order_to_sale_order/static/src/js/CreateOrderPopup.js
@@ -12,23 +12,32 @@ odoo.define("point_of_sale.CreateOrderPopup", function (require) {
         }
 
         async createDraftSaleOrder() {
-            await this._createSaleOrder("draft");
+            await this._actionCreateSaleOrder("draft");
         }
 
         async createConfirmedSaleOrder() {
-            await this._createSaleOrder("confirmed");
+            await this._actionCreateSaleOrder("confirmed");
         }
 
         async createDeliveredSaleOrder() {
-            await this._createSaleOrder("delivered");
+            await this._actionCreateSaleOrder("delivered");
+        }
+
+        async _actionCreateSaleOrder(order_state) {
+            // Create Sale Order
+            await this._createSaleOrder(order_state);
+
+            // Add new Order
+            this.env.pos.add_new_order();
+
+            // Close popup
+            return await super.confirm();
         }
 
         async _createSaleOrder(order_state) {
-            var current_order = this.env.pos.get_order();
-
+            const current_order = this.env.pos.get_order();
             framework.blockUI();
-
-            await this.rpc({
+            return await this.rpc({
                 model: "sale.order",
                 method: "create_order_from_pos",
                 args: [current_order.export_as_JSON(), order_state],
@@ -40,8 +49,6 @@ odoo.define("point_of_sale.CreateOrderPopup", function (require) {
                     framework.unblockUI();
                     current_order.destroy();
                 });
-
-            return await super.confirm();
         }
     }
 


### PR DESCRIPTION
Improvement for the ability to use the result of sales order creation after inheritance

Backport from 16.0: https://github.com/OCA/pos/pull/1035

When an order is created, a new one is not added in pos to be able to add new products.

**Before**
![antes](https://github.com/user-attachments/assets/202a5b93-ac38-46f4-8ea4-47eda80a8362)

**After**
![despues](https://github.com/user-attachments/assets/846dd1eb-1ebb-4c72-8181-a701fdc1a67c)

Please @pedrobaeza can you review it?

@Tecnativa TT56467****