### PR TITLE
[14.0][FIX] pos_payment_terminal: read payment method ids fron config

### DIFF
--- a/pos_payment_terminal/static/src/js/models.js
+++ b/pos_payment_terminal/static/src/js/models.js
@@ -24,7 +24,7 @@ odoo.define("pos_payment_terminal.models", function (require) {
     var _posmodelproto = models.PosModel.prototype;
     models.PosModel = models.PosModel.extend({
         after_load_server_data: function () {
-            for (var payment_method_id in this.payment_methods) {
+            for (var payment_method_id in this.config.payment_method_ids) {
                 var payment_method = this.payment_methods[payment_method_id];
                 if (payment_method.use_payment_terminal == "oca_payment_terminal") {
                     this.config.use_proxy = true;


### PR DESCRIPTION
Otherwise, it gets all payment methods even those that are not configured for the pos session, which leads to trying to use the proxy even if no payment mode that needs it is configured.