### PR TITLE
[16.0][FIX] pos_order_reorder: Conditional Display of "Repeat Order" Button Based on POS Setting

### DIFF
--- a/pos_order_reorder/static/src/xml/Screens/TicketScreen/TicketScreen.xml
+++ b/pos_order_reorder/static/src/xml/Screens/TicketScreen/TicketScreen.xml
@@ -11,7 +11,9 @@
             expr="//div[hasclass('leftpane')]//div[hasclass('control-buttons')]"
             position="inside"
         >
-            <ReorderButton order="_selectedSyncedOrder" />
+            <t t-if="env.pos.config.allow_reorder">
+                <ReorderButton order="_selectedSyncedOrder" />
+            </t>
         </xpath>
     </t>
 


### PR DESCRIPTION
### Description:
The "Allow Reorder" setting in the POS configuration was not functioning correctly. Regardless of whether the option was enabled or disabled, the "Repeat Order" button remained visible in the interface, potentially causing confusion and unintended duplicate orders.

### Cases Covered with This Improvement:

- Prevents the "Re-orderr" button from being displayed when the option is disabled in the POS settings.

- Ensures the feature behaves according to the user-defined configuration.

- Reduces the risk of incorrect order repetition in the sales environment.

### Implemented Solution:
A condition has been added to the code to control the visibility of the "Re-order" button based on the current value of the "Allow Reorder" setting. This ensures that the button is only shown when the option is enabled, aligning the functionality with the configured behavior in the POS.



FL-571-6323