### PR TITLE
[18.0][FIX] pos_lot_barcode: Collapse product array when length > 0

### DIFF
--- a/pos_lot_barcode/static/src/js/Screens/ProductScreen.esm.js
+++ b/pos_lot_barcode/static/src/js/Screens/ProductScreen.esm.js
@@ -66,10 +66,13 @@ patch(ProductScreen.prototype, {
                     ],
                     this.pos.data.fields["product.product"]
                 );
-                if (product.length > 1) {
-                    product = product[0];
-                    await this.pos.processProductAttributes();
+
+                if (product.length === 0) {
+                    return false; // not available in POS
                 }
+
+                product = product[0];
+                await this.pos.processProductAttributes();
             }
             return product;
         } else if (foundLotIds.length > 1) {


### PR DESCRIPTION
When scanning a lot/serial barcode that resolves to exactly **one** `stock.lot`, `_getProductByLotBarcode` fetches the related `product.product` via:
```js
product = await this.pos.data.searchRead("product.product", ...);
```
`searchRead` **always returns an array**. The current code only collapses the result when `length > 1`, so when `length === 1` the variable `product` remains an **Array** and is returned as such.

Upstream, `_barcodeLotAction` checks:
```js
if (product instanceof Array) {
    // treat as multiple lots, build a names string
    const productNamesString = product
        .map(
            (lot) => this.pos.models["product.product"].get(lot.product_id).name
        )
        .join(", ");
    ...
}
```
This branch **assumes** an array of **lots** (with `product_id`), but it actually receives an array of **products**. That mismatch raises an exception while accessing `lot.product_id` and then `.name` on an undefined lookup.

## Current behavior before PR
* Scanning a lot barcode that maps to one lot whose product isn’t yet cached in the POS frontend:
  * The function returns a **one-item product array**.
  * `_barcodeLotAction` treats it as **multiple lots** and executes the mapping above.
  * An exception is raised while building `productNamesString` instead of adding the product line because a product object does not have a product_id attribute, therefore this.pos.models["product.product"].get fails to look up the product

## Desired behavior after PR is merged
* Single-item results from `searchRead("product.product", ...)` are **collapsed to a record** (`product = product[0]`).
* `_barcodeLotAction` receives a **product record** (not an array) and proceeds to add the product to the order.
* If the search returns no records (`length === 0`), `_getProductByLotBarcode` correctly returns `false` (“not available in POS”).