### PR TITLE
[17.0][FIX] pos_user_restriction: fix broken test

### DIFF
--- a/pos_user_restriction/tests/test_hacks.py
+++ b/pos_user_restriction/tests/test_hacks.py
@@ -35,8 +35,7 @@ class TestHacks(TestPoSCommon):
 
     def test_get_closing_control_data(self):
         restricted_user = self.pos_user_assigned_pos
-        self.config = self._create_basic_config()
-        self.config.assigned_user_ids = [(6, 0, [restricted_user.id])]
+        self.basic_config.assigned_user_ids = [(6, 0, [restricted_user.id])]
 
         session = self.open_new_session()
 


### PR DESCRIPTION
### Note
- TestPoSCommon already triggered [_create_basic_config](https://github.com/odoo/odoo/blob/ed94e84d6a7cd5baf750a704697c869f254a8e26/addons/point_of_sale/tests/common.py#L203), duplication here results in broken CI