### PR TITLE
[FIX] pos_access_right: enforce payment button restriction in tablet mode

### DIFF
--- a/pos_access_right/static/src/css/pos.css
+++ b/pos_access_right/static/src/css/pos.css
@@ -5,6 +5,11 @@
     cursor: not-allowed;
 }
 
+.pos .switchpane .btn-switchpane.disabled-mode,
+.pos .switchpane .btn-switchpane.disabled-mode:hover {
+    display: none;
+}
+
 .pos .ticket-screen .controls button.highlight.disabled-mode:hover {
     background: #c7c7c7;
     border: solid 1px rgb(220, 220, 220);

--- a/pos_access_right/static/src/js/MobileOrderWidget.js
+++ b/pos_access_right/static/src/js/MobileOrderWidget.js
@@ -1,0 +1,17 @@
+odoo.define("pos_access_right.MobileOrderWidget", function (require) {
+    "use strict";
+
+    const Registries = require("point_of_sale.Registries");
+    const MobileOrderWidget = require("point_of_sale.MobileOrderWidget");
+
+    const PosMobileOrderWidget = (OriginalMobileOrderWidget) =>
+        class extends OriginalMobileOrderWidget {
+            get hasPaymentControlRights() {
+                return this.env.pos.user.hasGroupPayment;
+            }
+        };
+
+    Registries.Component.extend(MobileOrderWidget, PosMobileOrderWidget);
+
+    return MobileOrderWidget;
+});

--- a/pos_access_right/static/src/xml/MobileOrderWidget.xml
+++ b/pos_access_right/static/src/xml/MobileOrderWidget.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates id="template" xml:space="preserve">
+
+    <t
+        t-name="MobileOrderWidget"
+        t-inherit="point_of_sale.MobileOrderWidget"
+        t-inherit-mode="extension"
+        owl="1"
+    >
+        <xpath
+            expr="div[hasclass('switchpane')]//button[hasclass('btn-switchpane')]"
+            position="attributes"
+        >
+            <attribute
+                name="t-att-class"
+            >{'disabled-mode': !hasPaymentControlRights}</attribute>
+            <attribute name="t-att-disabled">!hasPaymentControlRights</attribute>
+        </xpath>
+    </t>
+
+</templates>


### PR DESCRIPTION
Previously, users without the required access rights could still access the payment button when switching to tablet mode in the POS interface. This bypassed the intended security restriction.

This fix ensures that the payment button remains disabled for unauthorized users regardless of the POS display mode.

Issue: Payment button enabled in tablet mode despite access restriction
