### PR TITLE
[FIX] duplicate container_deposit products in history

### DIFF
--- a/pos_container_deposit/__manifest__.py
+++ b/pos_container_deposit/__manifest__.py
@@ -4,7 +4,7 @@
     "category": "Point of Sale",
     "summary": "This module is used to manage container deposits for products"
     " in Point of Sale.",
-    "author": "Sunflower IT, Open2bizz, Odoo Community Association (OCA)",
+    "author": "Therp B.V., Sunflower IT, Open2bizz, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/pos",
     "license": "AGPL-3",
     "depends": ["point_of_sale"],

--- a/pos_container_deposit/readme/CONTRIBUTORS.rst
+++ b/pos_container_deposit/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 Tom Blauwendraat <tom@sunflowerweb.nl>
 Holger Brunn <mail@hunki-enterprises.com> (https://hunki-enterprises.com)
 Stefan Rijnhart <stefan@opener.am>
+Giovanni Francesco Capalbo <giovanni@therp.nl>

--- a/pos_container_deposit/static/src/js/models.js
+++ b/pos_container_deposit/static/src/js/models.js
@@ -40,7 +40,7 @@ odoo.define("pos_container_deposit.models", function (require) {
                  * When adding a product with container deposit, add its container deposit product
                  **/
                 super.add_orderline(...arguments);
-                // Get unpayed orders orders from db.pos
+                // Get unpayed orders from pos.orders wich comes from pos.db.orders
                 const all_unpaid = this.pos.get_order_list().map((x) => x.cid);
                 const is_unpaid = all_unpaid.includes(line.order.cid);
                 if (

--- a/pos_container_deposit/static/src/js/models.js
+++ b/pos_container_deposit/static/src/js/models.js
@@ -40,7 +40,14 @@ odoo.define("pos_container_deposit.models", function (require) {
                  * When adding a product with container deposit, add its container deposit product
                  **/
                 super.add_orderline(...arguments);
-                if (line.container_deposit_product && !line.container_deposit_line) {
+                // Get unpayed orders orders from db.pos
+                const all_unpaid = this.pos.get_order_list().map((x) => x.cid);
+                const is_unpaid = all_unpaid.includes(line.order.cid);
+                if (
+                    line.container_deposit_product &&
+                    !line.container_deposit_line &&
+                    is_unpaid
+                ) {
                     this.add_product(line.container_deposit_product, {
                         quantity: line.get_quantity(),
                     });


### PR DESCRIPTION
When visualizing paid orders, the container_products associated to a product  would show duplicated.

this is because after loading an existing pos.order from the backend, the code would still add another container_deposit_product, therefore duplicating them all , in visualization.

the problem was seen by users when accessing the "orders" icon, and visualizing paid orders, they would appear with duplicates. also the receipts, generated from that visualization were also incorrect.

This would only be a POS visualization problem, because the pos.order had been payed and closed and was not editable, but the visualization was broken, and also the receipts were printed wrong on every step of the way.

I initially tried to put a check on  init_from_Json, to stop the orders coming from json to have duplicates re-added, but thiswould not stop the duplicates from appearing on the currently active order, wich was also, at times loaded form json (e.g. page reload of the same session).

a simple way to stop the addition of the lines was to check the state, an open active order needs the container_deposit_product  , all the orders that have a state do not, they already have the container products added.

i prefer to check for` order.state == undefined`  to determine currently active order instead of    `  !['done', 'invoiced', 'paid'].includes(order.state) `  to cover future state extensions.

after few temporary solutions, i found no need to add flags in constructor of the order or  in init_from_Json. 

The option of sanitizing json source from the container_products and leaving the auto-add active for all orders is a bad idea, because it de-syncs odoo and pos.  if someone were to manually removes the container_deposit_product line from the backend , this will show the correct lines, without re-adding.

tested 25 minutes in various settings. undergoing more testing from others.