### PR TITLE
[FIX] duplicate container_deposit products in history

### DIFF
--- a/pos_container_deposit/static/src/js/models.js
+++ b/pos_container_deposit/static/src/js/models.js
@@ -40,7 +40,11 @@ odoo.define("pos_container_deposit.models", function (require) {
                  * When adding a product with container deposit, add its container deposit product
                  **/
                 super.add_orderline(...arguments);
-                if (line.container_deposit_product && !line.container_deposit_line) {
+                if (
+                    line.container_deposit_product &&
+                    !line.container_deposit_line &&
+                    this.state === undefined
+                ) {
                     this.add_product(line.container_deposit_product, {
                         quantity: line.get_quantity(),
                     });


### PR DESCRIPTION
The module adds an extra orderline for products that have a deposit product.
These deposit product orderlines are then saved in the backend upon confirmation.

Unfortunately, when loading history, the deposit product orderline , is both loaded from the backend and then re-added with the same logic, resulting in a double deposit product line. We need to distinguish orders loaded from backend from live orders loaded from pos.db.

We have found that the order state is a reliable criteria to stop re-adding the  deposit product , and determine it is already coming from the backend.  https://github.com/odoo/odoo/blob/16.0/addons/point_of_sale/static/src/js/models.js#L2664

Keeping the connection between the product, and it's added deposit would also be a solution, and stop the addition , but if the user changes the backend in any way (quantity, removing or adding deposit products) this type of sync would force additions customer may not want. We do not want this module to force modifications the user may have overridden.

