### PR TITLE
[16.0][FIX]pos_partner_birthdate :

### DIFF
--- a/pos_partner_birthdate/static/src/js/ClientDetailsEdit.esm.js
+++ b/pos_partner_birthdate/static/src/js/ClientDetailsEdit.esm.js
@@ -12,6 +12,12 @@ const PartnerDetailsEditBirthdate = (OriginalPartnerDetailsEdit) =>
                 birthdate_date: this.props.partner.birthdate_date || null,
             });
         }
+        async saveChanges() {
+            if (!this.changes.birthdate_date) {
+                this.changes.birthdate_date = false;
+            }
+            return await super.saveChanges(...arguments);
+        }
     };
 
 Registries.Component.extend(PartnerDetailsEdit, PartnerDetailsEditBirthdate);


### PR DESCRIPTION
### Description
A technical issue was identified in the POS customer creation/edition screen when handling the birthdate field. If a user accidentally selects a birthdate and subsequently clears the field, the system attempts to save an invalid value.

Due to the way the HTML5 date input behaves in the POS, clearing the field results in an empty string (" ") being stored in the component's state. When this value is sent to the server, it triggers a database integrity error because an empty string is not a valid format for a PostgreSQL DATE type.


### Cases Covered with This Improvement
This update introduces two fixes to ensure a smooth and error-free customer management flow:

1. **Data Normalization for SQL**: A new logic layer has been implemented to intercept empty date strings before they are sent to the backend. If the birthdate field is cleared, the value is automatically converted to false. This ensures that Odoo's ORM correctly interprets the value as NULL in the database, preventing the InvalidDatetimeFormat error.

### Implemented Solution
This issue was resolved by overriding the `saveChanges` method in the `PartnerDetailsEdit` component within `ClientDetailsEdit.esm.js`.

FL-571-7738