### PR TITLE
[16.0][IMP] pos_loyalty_exclude: Implementing logic to prevent the discount from being applied to excluded products.

### DIFF
--- a/pos_loyalty_exclude/__manifest__.py
+++ b/pos_loyalty_exclude/__manifest__.py
@@ -15,6 +15,9 @@
         "web.assets_tests": [
             "pos_loyalty_exclude/static/src/tours/**/*",
         ],
+        "point_of_sale.assets": [
+            "pos_loyalty_exclude/static/src/js/**/*",
+        ],
     },
     "auto_install": True,
 }

--- a/pos_loyalty_exclude/models/__init__.py
+++ b/pos_loyalty_exclude/models/__init__.py
@@ -1,1 +1,2 @@
 from . import loyalty_rule
+from . import pos_session

--- a/pos_loyalty_exclude/models/pos_session.py
+++ b/pos_loyalty_exclude/models/pos_session.py
@@ -1,0 +1,11 @@
+from odoo import models
+
+
+class PosShopModel(models.Model):
+    _inherit = "pos.session"
+
+    def _loader_params_product_product(self):
+        params = super()._loader_params_product_product()
+        if "search_params" in params and "fields" in params["search_params"]:
+            params["search_params"]["fields"].append("loyalty_exclude")
+        return params

--- a/pos_loyalty_exclude/static/src/js/Loyalty.esm.js
+++ b/pos_loyalty_exclude/static/src/js/Loyalty.esm.js
@@ -1,0 +1,66 @@
+/** @odoo-module **/
+
+import {Order} from "point_of_sale.models";
+import Registries from "point_of_sale.Registries";
+
+export const PosLoyaltyOrder = (OriginalOrder) =>
+    class extends OriginalOrder {
+        _getDiscountableOnOrder(reward) {
+            const result = super._getDiscountableOnOrder(reward);
+            const productExclude = this.orderlines.filter(
+                (line) => line.get_product().loyalty_exclude
+            );
+            for (const line of productExclude) {
+                const taxKey = ["ewallet", "gift_card"].includes(
+                    reward.program_id.program_type
+                )
+                    ? line.get_taxes().map((t) => t.id)
+                    : line
+                          .get_taxes()
+                          .filter((t) => t.amount_type !== "fixed")
+                          .map((t) => t.id);
+                result.discountable -= line.get_price_with_tax();
+                if (result.discountablePerTax[taxKey]) {
+                    result.discountablePerTax[taxKey] -= line.get_base_price();
+                }
+            }
+            return result;
+        }
+        _getCheapestLine() {
+            const result = super._getCheapestLine();
+            if (!result || !result.get_product().loyalty_exclude) {
+                return result;
+            }
+            let cheapestLine = null;
+            for (const line of this.get_orderlines().filter(
+                (l) => !l.get_product().loyalty_exclude
+            )) {
+                if (line.reward_id || !line.get_quantity()) {
+                    continue;
+                }
+                if (!cheapestLine || cheapestLine.price > line.price) {
+                    cheapestLine = line;
+                }
+            }
+            return cheapestLine;
+        }
+
+        getClaimableRewards(coupon_id = false, program_id = false, auto = false) {
+            const hasDiscountableLine = this.get_orderlines().some(
+                (line) => !line.get_product().loyalty_exclude && line.get_quantity()
+            );
+            if (hasDiscountableLine) {
+                return super.getClaimableRewards(coupon_id, program_id, auto);
+            }
+            return [];
+        }
+
+        _get_regular_order_lines() {
+            const orderLines = super._get_regular_order_lines();
+            if (orderLines) {
+                return orderLines.filter((line) => !line.get_product().loyalty_exclude);
+            }
+            return orderLines;
+        }
+    };
+Registries.Model.extend(Order, PosLoyaltyOrder);


### PR DESCRIPTION
## Description

An issue was identified in the loyalty discount logic where products marked with the option “Exclude product from discount programs” were still receiving discounts when added to the cart.

When a product configured as excluded was added to the cart, any active loyalty discount program was still applied to that product, regardless of its exclusion setting.


### Root Cause

The exclusion logic in the loyalty module was originally designed to manage point accumulation and free product rewards. However, it did not fully cover all types of loyalty discounts—specifically, discount-based rewards. As a result, products marked as excluded were still considered eligible for certain discount calculations.

This issue affected all discount configurations, including:

- Order-based discounts
- Cheapest product discounts

## Cases Covered with This Improvement

This update ensures that excluded products are properly ignored across all loyalty discount scenarios:

- Case 1: Automatic Discounts
When an excluded product is added to the cart and an automatic loyalty discount program is active:
The discount is no longer applied to the excluded product.
The reward button is not highlighted if only excluded products are present in the cart.

- Case 2: Discount Code Application
When an excluded product is added to the cart and a discount is applied via promo code:
The discount is not applied to the excluded product.
The loyalty exclusion logic is properly enforced.

Additionally, the fix ensures correct behavior across all discount calculation types:

- Order total–based rewards
- Cheapest product rewards
- Specific product rewards

## Implemented Solution

The solution introduces proper handling of the loyalty_exclude parameter at the POS JavaScript level.

The following logic adjustments were implemented:

- `_getDiscountableOnOrder`: Excluded products are no longer included in the reward amount calculation.
- `_getCheapestLine`: Excluded products are ignored when determining the cheapest product in the order.
- `getClaimableRewards`: If the cart contains only excluded products, the Rewards button is no longer highlighted.
- `_get_regular_order_lines`: apply the filter so that it does not add the excluded products.

These changes ensure that loyalty exclusions are consistently enforced across all discount types and reward calculations.

FL-571-7802