### PR TITLE
[16.0][FIX] pos_tare: support other decimal separators

### DIFF
--- a/pos_tare/static/src/js/Screens/ScaleScreen/ScaleScreen.esm.js
+++ b/pos_tare/static/src/js/Screens/ScaleScreen/ScaleScreen.esm.js
@@ -10,12 +10,17 @@ const TareScaleScreen = (ScaleScreen_) =>
     class extends ScaleScreen_ {
         setup() {
             super.setup();
+            this.decimalPoint = this.env._t.database.parameters.decimal_point;
             this.state = useState({
-                tare: this.props.product.tare_weight || "",
-                weight: 0,
-                gross_weight: "",
-                gross_weight_input_valid: true,
+                tare_str: this.props.product.tare_weight
+                    ? this._formatFloatValue(this.props.product.tare_weight)
+                    : "",
+                tare: this.props.product.tare_weight || 0,
                 tare_input_valid: true,
+                weight: 0,
+                gross_weight_str: "",
+                gross_weight: 0,
+                gross_weight_input_valid: true,
             });
             this.updateWeight();
             if (this.env.pos.config.iface_tare_method !== "manual") {
@@ -45,7 +50,7 @@ const TareScaleScreen = (ScaleScreen_) =>
         }
 
         async _barcodeTareAction(code) {
-            this.state.tare = code.value;
+            this.state.tare_str = this._formatFloatValue(code.value);
         }
 
         _readScale() {
@@ -57,6 +62,10 @@ const TareScaleScreen = (ScaleScreen_) =>
         async _setWeight() {
             await super._setWeight();
             this.state.gross_weight = this.state.weight;
+            // This is necessary to display the weight in the UI. It is not a
+            // string value in this case, which ensures that it won't be
+            // converted.
+            this.state.gross_weight_str = this.state.gross_weight;
             try {
                 this._computeWeight();
             } catch (error) {
@@ -87,12 +96,34 @@ const TareScaleScreen = (ScaleScreen_) =>
                 // called, and the weight is not computed in _computeWeight()
                 // when no tare is set to avoid a possible error). Therefore
                 // it needs to be set here.
-                this.state.weight = parseFloat(this.state.gross_weight);
+                this.state.weight = this.state.gross_weight;
             }
         }
 
+        _parseFloatValue(value) {
+            // Similar code as in Orderline.set_quantity(), to correctly
+            // handle different decimal separators and values that have
+            // already be converted from string to number.
+            if (typeof value === "number") {
+                return value;
+            }
+            // We don't use field_utils.parse.float() because we don't want to
+            // support thousands separators. There are locales where the
+            // thousands separator is a dot, and we want the user to be able
+            // to use the dot in addition to the locale's decimal separator.
+            return Number(value.replace(this.decimalPoint, "."));
+        }
+
+        _formatFloatValue(value) {
+            return String(value).replace(".", this.decimalPoint);
+        }
+
         _computeWeight() {
+            this.state.gross_weight = this._parseFloatValue(
+                this.state.gross_weight_str
+            );
             this.state.gross_weight_input_valid = !isNaN(this.state.gross_weight);
+            this.state.tare = this._parseFloatValue(this.state.tare_str);
             this.state.tare_input_valid = !isNaN(this.state.tare);
             if (!this.state.gross_weight_input_valid || !this.state.tare_input_valid) {
                 // This is to ensure that the resulting weight is invalid.
@@ -127,7 +158,7 @@ const TareScaleScreen = (ScaleScreen_) =>
                 payload: {
                     weight: {
                         weight: this.state.weight,
-                        tare: this.state.tare ? parseFloat(this.state.tare) : 0,
+                        tare: this.state.tare,
                     },
                 },
             });

--- a/pos_tare/static/src/js/models.esm.js
+++ b/pos_tare/static/src/js/models.esm.js
@@ -3,6 +3,7 @@
 import {convert_mass, format_tare} from "./tools.esm";
 import {Model} from "point_of_sale.Registries";
 import {Orderline} from "point_of_sale.models";
+import field_utils from "web.field_utils";
 
 const TareOrderline = (Orderline_) =>
     class extends Orderline_ {
@@ -56,11 +57,21 @@ const TareOrderline = (Orderline_) =>
                 this.reset_tare();
             }
 
+            if (quantity === "remove") {
+                return;
+            }
+
             // We convert the tare that is always measured in the same UoM into
             // the unit of measure for this order line.
             const tare_uom = this.pos.config.iface_tare_uom_id[0];
             const tare_unit = this.pos.units_by_id[tare_uom];
-            const tare = parseFloat(quantity) || 0;
+            // Same code as in Orderline.set_quantity(), to correctly handle
+            // different decimal separators and values that have already be
+            // converted from string to number.
+            const tare =
+                typeof quantity === "number"
+                    ? quantity
+                    : field_utils.parse.float(String(quantity ? quantity : 0));
             const line_unit = this.get_unit();
             // This will throw an exception if the UoM categories don't match.
             const tare_in_product_uom = convert_mass(tare, tare_unit, line_unit);

--- a/pos_tare/static/src/xml/Screens/ScaleScreen/ScaleScreen.xml
+++ b/pos_tare/static/src/xml/Screens/ScaleScreen/ScaleScreen.xml
@@ -13,7 +13,7 @@
             </div>
             <t t-if="env.pos.config.iface_gross_weight_method == 'scale'">
                 <div class="computed-price weight-value">
-                    <t t-out="state.gross_weight" /> <t t-out="gross_uom.name" />
+                    <t t-out="state.gross_weight_str" /> <t t-out="gross_uom.name" />
                 </div>
             </t>
             <t t-else="">
@@ -24,7 +24,7 @@
                         t-att-class="{'invalid-input': !state.gross_weight_input_valid}"
                         id="input_gross_weight"
                         placeholder="0"
-                        t-model="state.gross_weight"
+                        t-model="state.gross_weight_str"
                         t-on-input="updateWeight"
                     /> <t t-out="gross_uom.name" />
                 </div>
@@ -34,7 +34,7 @@
             </div>
             <t t-if="env.pos.config.iface_tare_method == 'barcode'">
                 <div class="computed-price weight-value">
-                    <t t-out="state.tare" /> <t
+                    <t t-out="state.tare_str" /> <t
                         t-out="env.pos.config.iface_tare_uom_id[1]"
                     />
                 </div>
@@ -47,7 +47,7 @@
                         t-att-class="{'invalid-input': !state.tare_input_valid}"
                         id="input_weight_tare"
                         placeholder="0"
-                        t-model="state.tare"
+                        t-model="state.tare_str"
                         t-on-input="updateWeight"
                     /> <t t-out="env.pos.config.iface_tare_uom_id[1]" />
                 </div>


### PR DESCRIPTION
ensure that the locale-defined decimal separator can be used to input tare values, and not only the dot (on the scale screen and on the product screen).