### PR TITLE
[FIX] pos_partner_firstname: avoid bug display in no responsive display. (classic computer)

### DIFF
--- a/pos_partner_firstname/static/src/xml/pos.xml
+++ b/pos_partner_firstname/static/src/xml/pos.xml
@@ -5,7 +5,7 @@
         <xpath expr="//input[@name='name']" position="attributes">
             <attribute
                 name="t-attf-style"
-            >display: {{changes.is_company ? 'block': 'none'}}</attribute>
+            >visibility: {{changes.is_company ? 'visible': 'hidden'}}</attribute>
         </xpath>
         <xpath expr="//div[hasclass('partner-details-left')]/div[1]" position="before">
             <div class="partner-detail">


### PR DESCRIPTION
Introduced by https://github.com/OCA/pos/pull/1153

Current display, in full screen mode, 


when is company is checked : OK

<img width="1090" height="359" alt="image" src="https://github.com/user-attachments/assets/9a0a5add-4eb2-4cbe-8d3b-17ce7d6fbdd8" />

when is company is not checked : KO

<img width="1093" height="475" alt="image" src="https://github.com/user-attachments/assets/69164864-5d5d-44a0-b934-77c9081a0863" />
 

CC original author : @alexis-via,
CC : reviewers : @flotho, @cvinh, @chienandalu
 