### PR TITLE
[FIX] pos_receipt_hide_info: remove question mark in field name.

### DIFF
--- a/pos_receipt_hide_info/models/pos_config.py
+++ b/pos_receipt_hide_info/models/pos_config.py
@@ -7,10 +7,10 @@ from odoo import fields, models
 class PosConfig(models.Model):
     _inherit = "pos.config"
 
-    hide_user = fields.Boolean(string="Hide User in POS receipt?", default=True)
+    hide_user = fields.Boolean(string="Hide User in POS receipt", default=True)
     hide_company_email = fields.Boolean(
-        string="Hide Company Email in POS receipt?", default=True
+        string="Hide Company Email in POS receipt", default=True
     )
     hide_company_phone = fields.Boolean(
-        string="Hide Company Phone in POS receipt?", default=True
+        string="Hide Company Phone in POS receipt", default=True
     )


### PR DESCRIPTION
Rational: In Odoo there is no boolean fields with question mark in the name. So we follow odoo / OCA convention and remove the character in the 3 fields and in the po / pot files.