### PR TITLE
[16.0][FIX] pos_partner_firstname: Fix DOM structure so Last Name and First Name fields are grouped in a single is_person container outside the Company checkbox block.

### DIFF
--- a/pos_partner_firstname/static/src/xml/pos.xml
+++ b/pos_partner_firstname/static/src/xml/pos.xml
@@ -18,28 +18,22 @@
                     t-on-change="captureChange"
                     t-model="changes.is_company"
                 />
-                <div
-                    class="is_person"
-                    t-on-change="captureChange"
-                    t-attf-style="display: {{!changes.is_company ? 'block': 'none'}};"
-                >
-                    <div class='partner-detail'>
-                        <span class='label'>Last Name</span>
-                        <input
-                            class='detail lastname person'
-                            name="lastname"
-                            t-on-change="captureChange"
-                            t-model="changes.lastname"
-                            placeholder="LastName"
-                        />
-                    </div>
-                </div>
             </div>
                 <div
                 class="is_person"
                 t-on-change="captureChange"
                 t-attf-style="display: {{!changes.is_company ? 'block': 'none'}};"
             >
+                    <div class='partner-detail'>
+                        <span class='label'>Last Name</span>
+                        <input
+                        class='detail lastname person'
+                        name="lastname"
+                        t-on-change="captureChange"
+                        t-model="changes.lastname"
+                        placeholder="LastName"
+                    />
+                    </div>
                     <div class='partner-detail'>
                         <span class='label'>First Name</span>
                         <input


### PR DESCRIPTION
### Description 
                                                                                                                
  It was identified that in the pos_partner_firstname module, the QWeb template for the partner details edit form had an incorrect DOM structure. The Last Name field was nested inside the `Company` checkbox container, while the
   First Name field was placed in a separate is_person wrapper outside of it.                                                                                                                                                      
                                                                                                                                                                                                                                   
  This caused two issues: the Last Name field inherited the layout context of the checkbox block (leading to visual misalignment in the POS interface), and the two person-specific fields were split across two independent       
  visibility containers instead of being grouped together.                                                                                                                                                                         
                                                                                                                                                                                                                                   
###   Cases Covered with This Fix

  - Prevents Last Name from being visually trapped inside the Company checkbox block.                                                                                                                                              
  - Ensures both Last Name and First Name are grouped within a single is_person container, so they show/hide consistently when toggling the `Company` checkbox.
  - Eliminates the duplicated is_person wrapper that caused redundant visibility logic.                                                                                                                                            
                                                                                                                                                                                                                                   
###   Implemented Solution                                                                                                                                                                                                             
                                                                                                                                                                                                                                   
  The QWeb template has been restructured so that the `is_person` div containing both Last Name and First Name fields is placed outside the Company checkbox `partner-detail` div, as a sibling element at the correct nesting level.  
   
  This guarantees a consistent DOM hierarchy where person-specific fields are properly grouped and the Company checkbox block remains self-contained.  
  
  FL-571-7734