### PR TITLE
[FIX] pos_order_to_sale_order_delivery: avoid to block settings, in demo instance.

### DIFF
--- a/pos_order_to_sale_order_delivery/models/pos_config.py
+++ b/pos_order_to_sale_order_delivery/models/pos_config.py
@@ -4,7 +4,7 @@ from odoo import fields, models
 class PosConfig(models.Model):
     _inherit = "pos.config"
 
-    iface_sale_order_allow_delivery = fields.Boolean(default=True)
+    iface_sale_order_allow_delivery = fields.Boolean()
     iface_sale_order_delivery_carrier_ids = fields.Many2many(
         comodel_name="delivery.carrier",
         relation="delivery_carrier_pos_config_rel",


### PR DESCRIPTION

Rational, when lauching runboat with that module installed, it is not possible to configure settings. (write on res.config.settings model) because the field pos_iface_sale_order_delivery_carrier_ids is required when pos_iface_sale_order_allow_delivery is True. This trivial patch fixes this problem