### PR TITLE
[16.0][IMP] pos_restaurant_receipt_usability patch instead of extend

### DIFF
--- a/pos_restaurant_receipt_usability/static/src/js/SplitBillScreen.js
+++ b/pos_restaurant_receipt_usability/static/src/js/SplitBillScreen.js
@@ -1,22 +1,38 @@
 /*
 Copyright (C) 2024-Today: GRAP (http://www.grap.coop)
-@author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+@author: Sylvain LE GAL
+@author: Quentin DUPONT
 License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 */
 
-odoo.define("pos_restaurant_receipt_usability.SplitBillScreen", function (require) {
-    "use strict";
+odoo.define(
+    "pos_restaurant_receipt_usability.SplitBillScreenPatchReceipt",
+    function (require) {
+        "use strict";
 
-    const SplitBillScreen = require("pos_restaurant.SplitBillScreen");
-    const Registries = require("point_of_sale.Registries");
+        const SplitBillScreen = require("pos_restaurant.SplitBillScreen");
+        const {patch} = require("web.utils");
+        const Registries = require("point_of_sale.Registries");
 
-    const OverloadSplitBillScreen = (OriginalSplitBillScreen) =>
-        class extends OriginalSplitBillScreen {
-            render() {
-                // Link the new created order with the original one
-                this.newOrder.splitted_order = this.env.pos.get_order();
+        patch(
+            SplitBillScreen.prototype,
+            "pos_restaurant_split_order_usability.SplitBillScreenPatchReceipt",
+            {
+                /**
+                 * Link the new created order with the original one
+                 */
+                proceed() {
+                    if (this.newOrder) {
+                        this.newOrder.splitted_order = this.env.pos.get_order();
+                    }
+                    if (this._super) {
+                        this._super(...arguments);
+                    }
+                },
             }
-        };
-    Registries.Component.extend(SplitBillScreen, OverloadSplitBillScreen);
-    return SplitBillScreen;
-});
+        );
+
+        Registries.Component.add(SplitBillScreen);
+        return SplitBillScreen;
+    }
+);


### PR DESCRIPTION
Patch instead of extending to make other module works, like `pos_restaurant_split_order_usability` https://github.com/OCA/pos/pull/1512