### PR TITLE
[18.0][FIX] pos_product_display_default_code: skip opening control in test tour

### DIFF
--- a/pos_product_display_default_code/static/tests/tours/product_screen_tour.esm.js
+++ b/pos_product_display_default_code/static/tests/tours/product_screen_tour.esm.js
@@ -1,5 +1,4 @@
 import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
-import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_screen_util";
 import {registry} from "@web/core/registry";
 
@@ -7,7 +6,6 @@ registry.category("web_tour.tours").add("SearchProductByDefaultCode", {
     steps: () =>
         [
             Chrome.startPoS(),
-            Dialog.confirm("Open Register"),
             ProductScreen.searchProduct("chair"),
             ProductScreen.clickDisplayedProduct("[CHAIR_01] Test sofa"),
             Chrome.endTour(),

--- a/pos_product_display_default_code/tests/test_frontend.py
+++ b/pos_product_display_default_code/tests/test_frontend.py
@@ -15,6 +15,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         )
         self.main_pos_config.display_default_code = True
         self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.main_pos_config.current_session_id.set_opening_control(0, "")
         self.start_tour(
             "/pos/ui?config_id=%d" % self.main_pos_config.id,
             "SearchProductByDefaultCode",


### PR DESCRIPTION
The tour clicks "Open Register" to confirm the opening cash, but in CI the `set_opening_control` RPC takes ~10s to respond. While waiting, the popup remains open and blocks the next tour step (product search), causing a timeout.

```
FAILED: [4/6] Tour SearchProductByDefaultCode → Step Search for a product using the search bar (trigger: .pos-rightheader .form-control > input).
Element has been found.
BUT: It is not allowed to do action on an element that's below a modal.
TIMEOUT step failed to complete within 10000 ms.
```

To fix this, `set_opening_control(0, "")` is called in test_frontend.py before starting the tour so the session is already opened and the popup never appears, removing the need for the `Dialog.confirm("Open Register")` step in the tour.

@Tecnativa
@pedrobaeza @christian-ramos-tecnativa 