### PR TITLE
[18.0][FIX] pos_order_to_sale_order: skip opening control in test tour

### DIFF
--- a/pos_order_to_sale_order/static/tests/tours/PosOrderToSaleOrderTour.tour.esm.js
+++ b/pos_order_to_sale_order/static/tests/tours/PosOrderToSaleOrderTour.tour.esm.js
@@ -6,7 +6,6 @@
 */
 
 import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
-import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_screen_util";
 import * as PosOrderToSaleOrderScreen from "./helpers/PosOrderToSaleOrderMethods.esm";
 import {registry} from "@web/core/registry";
@@ -15,7 +14,6 @@ registry.category("web_tour.tours").add("PosOrderToSaleOrderTour", {
     steps: () =>
         [
             Chrome.startPoS(),
-            Dialog.confirm("Open Register"),
             ProductScreen.addOrderline("Whiteboard Pen", "1"),
             ProductScreen.addOrderline("Wall Shelf Unit", "1"),
             ProductScreen.addCustomerNote("Product Note"),

--- a/pos_order_to_sale_order/tests/test_module.py
+++ b/pos_order_to_sale_order/tests/test_module.py
@@ -11,6 +11,7 @@ from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCom
 class TestUi(TestPointOfSaleHttpCommon):
     def test_pos_order_to_sale_order(self):
         self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.main_pos_config.current_session_id.set_opening_control(0, "")
 
         # Make the test compatible with pos_minimize_menu
         if "iface_important_buttons" in self.main_pos_config._fields:


### PR DESCRIPTION
The tour clicks "Open Register" to confirm the opening cash, but in CI the `set_opening_control` RPC takes ~10s to respond. While waiting, the popup remains open and blocks the next tour step (product search), causing a timeout.

```
FAILED: [3/29] Tour PosOrderToSaleOrderTour → Step click product 'Whiteboard Pen' (trigger: article.product .product-content .product-name:contains("Whiteboard Pen")).
Element has been found.
BUT: It is not allowed to do action on an element that's below a modal.
TIMEOUT step failed to complete within 10000 ms.
```

To fix this, `set_opening_control(0, "")` is called in `test_frontend.py` before starting the tour so the session is already opened and the popup never appears, removing the need for the `Dialog.confirm("Open Register")` step in the tour.

@Tecnativa 
@pedrobaeza @christian-ramos-tecnativa 
