### PR TITLE
[18.0][FIX] pos_order_to_sale_order: fix delivery_status not updated on invoiced order

### DIFF
--- a/pos_order_to_sale_order/models/sale_order.py
+++ b/pos_order_to_sale_order/models/sale_order.py
@@ -54,6 +54,9 @@ class SaleOrder(models.Model):
             for move in sale_order.mapped("picking_ids.move_ids_without_package"):
                 move.quantity = move.product_uom_qty
             sale_order.mapped("picking_ids").button_validate()
+            pickings = sale_order.picking_ids
+            if pickings and all(p.state in ("done", "cancel") for p in pickings):
+                sale_order.write({"delivery_status": "full"})
 
         if action in ["invoiced"]:
             # Create and confirm invoices

--- a/pos_order_to_sale_order/tests/test_module.py
+++ b/pos_order_to_sale_order/tests/test_module.py
@@ -9,6 +9,12 @@ from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCom
 
 @tagged("post_install", "-at_install")
 class TestUi(TestPointOfSaleHttpCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.whiteboard_pen.is_storable = True
+        cls.wall_shelf.is_storable = True
+
     def test_pos_order_to_sale_order(self):
         self.main_pos_config.with_user(self.pos_user).open_ui()
 


### PR DESCRIPTION
In Odoo 18, `is_storable` defaults to `False`, so no pickings are created when confirming the sale order. Additionally, the stored field `delivery_status` is not automatically recomputed after `button_validate()` in this RPC context, causing the following failure:

```
Traceback (most recent call last):
  File "/opt/odoo/auto/addons/pos_order_to_sale_order/tests/test_module.py", line 47, in test_pos_order_to_sale_order
    self.assertEqual(
AssertionError: False != 'full' : Delivery status must be equal to 'full'
```

To fix this, `setUpClass` is overridden to set `is_storable = True` on the test products, and `create_order_from_pos` is updated to explicitly write `delivery_status = 'full'` after all pickings are validated.

@Tecnativa
@pedrobaeza  @christian-ramos-tecnativa 