### PR TITLE
[18.0][FIX] pos_margin: Remove margin data on the ticket

### DIFF
--- a/pos_margin/static/src/js/models.esm.js
+++ b/pos_margin/static/src/js/models.esm.js
@@ -26,6 +26,15 @@ patch(PosOrder.prototype, {
     get_margin_rate_str() {
         return roundCurrency(this.get_margin_rate(), this.currency) + "%";
     },
+
+    export_for_printing(baseUrl, headerData) {
+        const result = super.export_for_printing(baseUrl, headerData);
+        result.orderlines = result.orderlines.map((line) => ({
+            ...line,
+            ifaceDisplayMargin: false,
+        }));
+        return result;
+    },
 });
 
 // /////////////////////////////

--- a/pos_margin/static/src/xml/pos_margin.xml
+++ b/pos_margin/static/src/xml/pos_margin.xml
@@ -28,7 +28,9 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
     <t t-inherit="point_of_sale.OrderWidget" t-inherit-mode="extension">
         <xpath expr="//t[@t-slot='details']" position="before">
-            <OrderSummaryMargin />
+            <t t-if="!props.screenName">
+                <OrderSummaryMargin />
+            </t>
         </xpath>
     </t>
 


### PR DESCRIPTION
Remove margin data on the ticket

**Before**
<img width="639" height="790" alt="antes" src="https://github.com/user-attachments/assets/8e88d2fe-a579-432b-8dd8-795dbe7fc841" />

**After**
<img width="662" height="790" alt="despues" src="https://github.com/user-attachments/assets/193e1288-6b76-4abb-9876-0cce338fc927" />

Please  @pedrobaeza can you review it?

@Tecnativa TT62342