### PR TITLE
[17.0][FIX] pos_margin: Remove margin data on the ticket

### DIFF
--- a/pos_margin/static/src/js/models.esm.js
+++ b/pos_margin/static/src/js/models.esm.js
@@ -24,6 +24,14 @@ patch(Order.prototype, {
     get_margin_rate_str() {
         return this.env.utils.roundCurrency(this.get_margin_rate()) + "%";
     },
+    export_for_printing() {
+        const result = super.export_for_printing();
+        result.orderlines = result.orderlines.map((line) => ({
+            ...line,
+            ifaceDisplayMargin: false,
+        }));
+        return result;
+    },
 });
 
 // /////////////////////////////

--- a/pos_margin/static/src/xml/pos_margin.xml
+++ b/pos_margin/static/src/xml/pos_margin.xml
@@ -28,7 +28,9 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
     <t t-inherit="point_of_sale.OrderWidget" t-inherit-mode="extension">
         <xpath expr="//t[@t-slot='details']" position="before">
-            <OrderSummaryMargin />
+            <t t-if="props.editable">
+                <OrderSummaryMargin />
+            </t>
         </xpath>
     </t>
 


### PR DESCRIPTION
Backport from 18.0: https://github.com/OCA/pos/pull/1549

Remove margin data on the ticket

**Before**
<img width="488" height="737" alt="antes" src="https://github.com/user-attachments/assets/60eb7829-1bd1-487f-98ec-68f8ca13c75c" />

**After**
<img width="478" height="733" alt="despues" src="https://github.com/user-attachments/assets/2815b5cd-1afb-47ec-a543-cb78f8f444d1" />


Please  @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT62342