### PR TITLE
[IMP] pos_place: hide place_id by default;

### DIFF
--- a/pos_place/views/view_account_move.xml
+++ b/pos_place/views/view_account_move.xml
@@ -32,7 +32,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                 <field
                     name="place_id"
                     groups="pos_place.group_pos_place_user"
-                    optional="show"
+                    optional="hide"
                 />
             </field>
         </field>


### PR DESCRIPTION
Rational : the field is useless in most of the use case. user can display it if desired. making field optional