### PR TITLE
[16.0][FIX] pos_tare: fix weight formatting on receipt

### DIFF
--- a/pos_tare/i18n/fr.po
+++ b/pos_tare/i18n/fr.po
@@ -18,165 +18,118 @@ msgstr ""
 "X-Generator: Weblate 5.15.2\n"
 
 #. module: pos_tare
-#. openerp-web
-#: code:addons/pos_tare/static/src/xml/pos_tare.xml:36
+#. odoo-javascript
+#: code:addons/pos_tare/static/src/xml/Screens/ProductScreen/Orderline.xml:0
 #, python-format
 msgid "- Tare:"
-msgstr "- Tare :"
-
-#. module: pos_tare
-#: selection:barcode.rule,type:0
-msgid "Alias"
-msgstr "Alias"
-
-#. module: pos_tare
-#. openerp-web
-#: code:addons/pos_tare/static/src/xml/pos_tare.xml:103
-#, python-format
-msgid "Backspace"
-msgstr "Retour arrière"
+msgstr "- Tare :"
 
 #. module: pos_tare
 #: model:ir.model,name:pos_tare.model_barcode_rule
 msgid "Barcode Rule"
-msgstr "Règle de code barre"
+msgstr "Règle de code-barres"
 
 #. module: pos_tare
-#: selection:barcode.rule,type:0
-msgid "Cashier"
-msgstr "Caissier"
-
-#. module: pos_tare
-#: model:product.product,name:pos_tare.cheese
 #: model:product.template,name:pos_tare.cheese_product_template
 msgid "Cheese by the Slice"
 msgstr "Fromage à la coupe"
 
 #. module: pos_tare
-#: selection:barcode.rule,type:0
-msgid "Client"
-msgstr "Client"
+#: model:ir.model,name:pos_tare.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
 
 #. module: pos_tare
-#: model_terms:ir.ui.view,arch_db:pos_tare.view_pos_config_form
+#: model_terms:ir.ui.view,arch_db:pos_tare.res_config_settings_view_form
 msgid "Configure how to input Gross Weight."
 msgstr "Configurer comment saisir le poids brut."
 
 #. module: pos_tare
-#: model_terms:ir.ui.view,arch_db:pos_tare.view_pos_config_form
+#: model_terms:ir.ui.view,arch_db:pos_tare.res_config_settings_view_form
 msgid "Configure how to tare products to weight with a scale."
 msgstr "Configuer comment tarer les produits à peser avec la balance."
 
 #. module: pos_tare
-#. openerp-web
-#: code:addons/pos_tare/static/src/xml/pos_tare.xml:94
+#. odoo-javascript
+#: code:addons/pos_tare/static/src/js/Screens/ProductScreen/ProductScreen.esm.js:0
+#: code:addons/pos_tare/static/src/js/Screens/ScaleScreen/ScaleScreen.esm.js:0
 #, python-format
-msgid "Disc"
-msgstr "Rem."
+msgid "Error Computing Weight"
+msgstr "Erreur de calcul du poids"
 
 #. module: pos_tare
-#: selection:barcode.rule,type:0
-msgid "Discounted Product"
-msgstr "Article en promotion"
-
-#. module: pos_tare
-#. openerp-web
-#: code:addons/pos_tare/static/src/js/screens.js:185
+#. odoo-javascript
+#: code:addons/pos_tare/static/src/js/Screens/ProductScreen/ProductScreen.esm.js:0
 #, python-format
 msgid "Feature Disabled"
 msgstr "Fonctionnalité désactivée"
 
 #. module: pos_tare
-#. openerp-web
-#: code:addons/pos_tare/static/src/xml/pos_tare.xml:7
+#. odoo-javascript
+#: code:addons/pos_tare/static/src/xml/Screens/ScaleScreen/ScaleScreen.xml:0
 #, python-format
 msgid "Gross Weight"
 msgstr "Poids brut"
 
 #. module: pos_tare
-#. openerp-web
-#: code:addons/pos_tare/static/src/xml/pos_tare.xml:48
-#, python-format
-msgid "Gross Weight :"
-msgstr "Poids brut :"
-
-#. module: pos_tare
 #: model:ir.model.fields,field_description:pos_tare.field_pos_config__iface_gross_weight_method
-#: model_terms:ir.ui.view,arch_db:pos_tare.view_pos_config_form
+#: model:ir.model.fields,field_description:pos_tare.field_res_config_settings__pos_iface_gross_weight_method
+#: model_terms:ir.ui.view,arch_db:pos_tare.res_config_settings_view_form
 msgid "Gross Weight Input Method"
 msgstr "Méthode de saisie du poids brut"
 
 #. module: pos_tare
-#. openerp-web
-#: code:addons/pos_tare/static/src/xml/pos_tare.xml:34
+#. odoo-javascript
+#: code:addons/pos_tare/static/src/xml/Screens/ProductScreen/Orderline.xml:0
+#: code:addons/pos_tare/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml:0
 #, python-format
 msgid "Gross Weight:"
-msgstr "Poids brut :"
+msgstr "Poids brut :"
 
 #. module: pos_tare
-#. openerp-web
-#: code:addons/pos_tare/static/src/js/screens.js:91
+#. odoo-javascript
+#: code:addons/pos_tare/static/src/js/Screens/ProductScreen/ProductScreen.esm.js:0
 #, python-format
 msgid "Incorrect Gross Weight Value"
 msgstr "Poids brut incorrecte"
 
 #. module: pos_tare
-#. openerp-web
-#: code:addons/pos_tare/static/src/js/screens.js:85
+#. odoo-javascript
+#: code:addons/pos_tare/static/src/js/Screens/ProductScreen/ProductScreen.esm.js:0
 #, python-format
 msgid "Incorrect Tare Value"
 msgstr "Tare incorrecte"
 
 #. module: pos_tare
-#: selection:pos.config,iface_gross_weight_method:0
+#: model:ir.model.fields.selection,name:pos_tare.selection__pos_config__iface_gross_weight_method__scale
 msgid "Input Gross Weight via Scale"
 msgstr "Saisir le poids brut via la balance"
 
 #. module: pos_tare
-#: selection:pos.config,iface_gross_weight_method:0
+#: model:ir.model.fields.selection,name:pos_tare.selection__pos_config__iface_gross_weight_method__manual
 msgid "Input the Gross Weight manually"
 msgstr "Saisir le poids brut manuellement"
 
 #. module: pos_tare
-#: selection:pos.config,iface_tare_method:0
+#: model:ir.model.fields.selection,name:pos_tare.selection__pos_config__iface_tare_method__manual
 msgid "Input the tare manually"
 msgstr "Saisir la tare manuellement"
 
 #. module: pos_tare
-#: selection:barcode.rule,type:0
-msgid "Location"
-msgstr "Lieu"
-
-#. module: pos_tare
-#: selection:barcode.rule,type:0
-msgid "Lot"
-msgstr "Lot"
-
-#. module: pos_tare
-#: selection:pos.config,iface_tare_method:0
+#: model:ir.model.fields.selection,name:pos_tare.selection__pos_config__iface_tare_method__both
 msgid "Manual input and barcode"
-msgstr "Saisie manuelle et par code barre"
+msgstr "Saisie manuelle et par code-barres"
 
 #. module: pos_tare
-#: selection:barcode.rule,type:0
-msgid "Meal Voucher Payment"
-msgstr "Bon (Ticket-resto)"
-
-#. module: pos_tare
-#: selection:barcode.rule,type:0
-msgid "Package"
-msgstr "Colis"
-
-#. module: pos_tare
-#. openerp-web
-#: code:addons/pos_tare/static/src/js/screens.js:92
+#. odoo-javascript
+#: code:addons/pos_tare/static/src/js/Screens/ProductScreen/ProductScreen.esm.js:0
 #, python-format
 msgid "Please set a numeric value in the gross weight field."
 msgstr "Veuillez saisir une valeur numérique pour le poids brut."
 
 #. module: pos_tare
-#. openerp-web
-#: code:addons/pos_tare/static/src/js/screens.js:86
+#. odoo-javascript
+#: code:addons/pos_tare/static/src/js/Screens/ProductScreen/ProductScreen.esm.js:0
 #, python-format
 msgid "Please set a numeric value in the tare field, or let empty."
 msgstr "Veuillez saisir une valeur numérique pour la tare, ou laisser vide."
@@ -192,94 +145,70 @@ msgid "Point of Sale Order Lines"
 msgstr "Lignes des commandes du point de vente"
 
 #. module: pos_tare
-#. openerp-web
-#: code:addons/pos_tare/static/src/xml/pos_tare.xml:100
-#, python-format
-msgid "Price"
-msgstr "Prix"
-
-#. module: pos_tare
-#: selection:barcode.rule,type:0
-msgid "Priced Product"
-msgstr "Article à prix fixe"
-
-#. module: pos_tare
-#: selection:barcode.rule,type:0
-msgid "Priced Product (Computed Weight)"
-msgstr "Produit tarifé (poids calculé)"
+#: model:ir.model,name:pos_tare.model_pos_session
+msgid "Point of Sale Session"
+msgstr "Session du point de vente"
 
 #. module: pos_tare
 #: model:ir.model,name:pos_tare.model_product_template
-msgid "Product Template"
-msgstr "Modèle d'article"
+msgid "Product"
+msgstr "Produit"
 
 #. module: pos_tare
-#. openerp-web
-#: code:addons/pos_tare/static/src/xml/pos_tare.xml:82
-#, python-format
-msgid "Qty"
-msgstr "Qté"
-
-#. module: pos_tare
-#. openerp-web
-#: code:addons/pos_tare/static/src/js/screens.js:97
+#. odoo-javascript
+#: code:addons/pos_tare/static/src/js/Screens/ProductScreen/ProductScreen.esm.js:0
 #, python-format
 msgid "Quantity lower or equal to zero"
 msgstr "Quantité inférieure ou égale à zéro"
 
 #. module: pos_tare
-#: selection:pos.config,iface_tare_method:0
+#: model:ir.model.fields.selection,name:pos_tare.selection__pos_config__iface_tare_method__barcode
 msgid "Scan a barcode to set the tare"
-msgstr "Scanner un code barre pour appliquer une tare"
+msgstr "Scanner un code-barres pour appliquer une tare"
 
 #. module: pos_tare
 #: model:ir.model.fields,help:pos_tare.field_pos_config__iface_tare_method
+#: model:ir.model.fields,help:pos_tare.field_res_config_settings__pos_iface_tare_method
 msgid ""
 "Select tare method:\n"
-"* 'manual' : the scale screen has an extra tare input field;\n"
-"* 'barecode' : (scan a barcode to tare the selected order line;\n"
-"* 'both' : manual input and barcode methods are enabled;"
+"* 'manual': the scale screen has an extra tare input field;\n"
+"* 'barcode': scan a barcode to tare the selected order line;\n"
+"* 'both': manual input and barcode methods are enabled;"
 msgstr ""
-"Selection la méthode de tare : \n"
-"* 'manuelle' : l'écran de pesée à un nouveau champ de saisie pour la tare ;\n"
-"* 'code barre' : scanner un code bare pour tarer la ligne sélectionnée ;\n"
-"* 'les deux' : Saisie manuelle ou par code barre ;"
+"Selection de la méthode de tare : \n"
+"* 'manuelle' : l'écran de pesée a un nouveau champ de saisie pour la tare ;\n"
+"* 'code-barres' : scanner un code-barres pour tarer la ligne sélectionnée ;\n"
+"* 'les deux' : saisie manuelle ou par code-barres ;"
 
 #. module: pos_tare
 #: model:ir.model.fields,help:pos_tare.field_product_product__tare_weight
 #: model:ir.model.fields,help:pos_tare.field_product_template__tare_weight
 msgid ""
 "Set here Constant tare weight for the given product. This tare will be "
-"substracted when the product is weighted"
+"subtracted when the product is weighed."
 msgstr ""
 "Saisir une valeur de tare par défaut pour ce produit. Cette tare sera "
-"soustraite quand le produit est pesée"
+"soustraite quand le produit est pesé."
 
 #. module: pos_tare
-#. openerp-web
-#: code:addons/pos_tare/static/src/xml/pos_tare.xml:19
-#: code:addons/pos_tare/static/src/xml/pos_tare.xml:88
-#: selection:barcode.rule,type:0
+#. odoo-javascript
+#: code:addons/pos_tare/static/src/xml/Screens/ProductScreen/NumpadWidget.xml:0
+#: code:addons/pos_tare/static/src/xml/Screens/ScaleScreen/ScaleScreen.xml:0
 #: model:ir.model.fields,field_description:pos_tare.field_pos_order_line__tare
+#: model:ir.model.fields.selection,name:pos_tare.selection__barcode_rule__type__tare
 #, python-format
 msgid "Tare"
 msgstr "Tare"
 
 #. module: pos_tare
-#. openerp-web
-#: code:addons/pos_tare/static/src/xml/pos_tare.xml:50
-#, python-format
-msgid "Tare :"
-msgstr "Tare :"
-
-#. module: pos_tare
 #: model:ir.model.fields,field_description:pos_tare.field_pos_config__iface_tare_method
-#: model_terms:ir.ui.view,arch_db:pos_tare.view_pos_config_form
+#: model:ir.model.fields,field_description:pos_tare.field_res_config_settings__pos_iface_tare_method
+#: model_terms:ir.ui.view,arch_db:pos_tare.res_config_settings_view_form
 msgid "Tare Input Method"
 msgstr "Méthode de saisie de la tare"
 
 #. module: pos_tare
-#: model_terms:ir.ui.view,arch_db:pos_tare.view_pos_config_form
+#: model_terms:ir.ui.view,arch_db:pos_tare.res_config_settings_view_form
 msgid "Tare UoM"
 msgstr "UdM de la tare"
 
@@ -290,76 +219,66 @@ msgid "Tare Weight"
 msgstr "Poids de la tare"
 
 #. module: pos_tare
-#. openerp-web
-#: code:addons/pos_tare/static/src/js/screens.js:98
+#. odoo-javascript
+#: code:addons/pos_tare/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml:0
+#, python-format
+msgid "Tare:"
+msgstr "Tare :"
+
+#. module: pos_tare
+#. odoo-javascript
+#: code:addons/pos_tare/static/src/js/Screens/ProductScreen/ProductScreen.esm.js:0
 #, python-format
 msgid ""
 "The quantity is lower or equal to zero. Are you sure you want to continue ?"
 msgstr ""
 "La quantité est inférieure ou égale à zéro. Etes-vous sûr de vouloir "
-"continuer ?"
+"continuer ?"
 
 #. module: pos_tare
 #: model:ir.model.fields,field_description:pos_tare.field_barcode_rule__type
 msgid "Type"
-msgstr "Genre"
-
-#. module: pos_tare
-#: selection:barcode.rule,type:0
-msgid "Unit Product"
-msgstr "Unité de produit"
+msgstr "Type"
 
 #. module: pos_tare
 #: model:ir.model.fields,field_description:pos_tare.field_pos_config__iface_tare_uom_id
+#: model:ir.model.fields,field_description:pos_tare.field_res_config_settings__pos_iface_tare_uom_id
 msgid "Unit of Measure of the tare"
 msgstr "Unité de mesure de la tare"
 
 #. module: pos_tare
-#: model_terms:ir.ui.view,arch_db:pos_tare.view_pos_config_form
+#: model_terms:ir.ui.view,arch_db:pos_tare.res_config_settings_view_form
 msgid "Unit of Measure of the tares."
 msgstr "Unité de mesure des tares."
 
 #. module: pos_tare
-#. openerp-web
-#: code:addons/pos_tare/static/src/js/screens.js:23
+#. odoo-javascript
+#: code:addons/pos_tare/static/src/js/Screens/ProductScreen/ProductScreen.esm.js:0
 #, python-format
-msgid "We can not apply this tare barcode."
-msgstr "Impossible d'appliquer ce code barre de tare."
+msgid "We cannot apply this tare"
+msgstr "Impossible d'appliquer cette tare"
 
 #. module: pos_tare
-#. openerp-web
-#: code:addons/pos_tare/static/src/js/screens.js:194
+#. odoo-javascript
+#: code:addons/pos_tare/static/src/js/Screens/ProductScreen/ProductScreen.esm.js:0
 #, python-format
-msgid "We can not apply this tare."
-msgstr "Impossible d'appliquer cette tare."
+msgid "We cannot apply this tare barcode"
+msgstr "Impossible d'appliquer ce code-barres de tare"
 
 #. module: pos_tare
-#. openerp-web
-#: code:addons/pos_tare/static/src/js/tools.js:17
+#. odoo-javascript
+#: code:addons/pos_tare/static/src/js/tools.esm.js:0
 #, python-format
-msgid "We can not cast a weight in %s into %s."
+msgid "We cannot cast a weight in %s into %s."
 msgstr "Impossible de convertir le poids de %s à %s."
 
 #. module: pos_tare
-#: selection:barcode.rule,type:0
-msgid "Weighted Product"
-msgstr "Article pesé"
-
-#. module: pos_tare
-#. openerp-web
-#: code:addons/pos_tare/static/src/js/screens.js:186
+#. odoo-javascript
+#: code:addons/pos_tare/static/src/js/Screens/ProductScreen/ProductScreen.esm.js:0
 #, python-format
 msgid ""
 "You can not set the tare. To be able to set the tare manually you have to "
-"change the tare input method in the POS configuration."
+"change the tare input method in the POS configuration"
 msgstr ""
 "Vous ne pouvez pas saisir manuellement la tare. pour le faire, veuillez "
 "changer la configuration de votre point de vente."
-
-#. module: pos_tare
-#: model:product.product,uom_name:pos_tare.cheese
-#: model:product.product,weight_uom_name:pos_tare.cheese
-#: model:product.template,uom_name:pos_tare.cheese_product_template
-#: model:product.template,weight_uom_name:pos_tare.cheese_product_template
-msgid "kg"
-msgstr "kg"

--- a/pos_tare/static/src/js/models.esm.js
+++ b/pos_tare/static/src/js/models.esm.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import {convert_mass, format_tare} from "./tools.esm";
+import {convert_mass, format_quantity} from "./tools.esm";
 import {Model} from "point_of_sale.Registries";
 import {Orderline} from "point_of_sale.models";
 import field_utils from "web.field_utils";
@@ -39,8 +39,9 @@ const TareOrderline = (Orderline_) =>
 
         export_for_printing() {
             const order_line = super.export_for_printing(...arguments);
-            order_line.tare_quantity = this.get_tare();
-            order_line.gross_quantity = this.get_gross_weight();
+            order_line.has_tare = this.has_tare;
+            order_line.tare_str = this.get_tare_str_with_unit();
+            order_line.gross_weight_str = this.get_gross_weight_str_with_unit();
             return order_line;
         }
 
@@ -51,7 +52,7 @@ const TareOrderline = (Orderline_) =>
             this.order.assert_editable();
 
             // Prevent to apply multiple times a tare to the same product.
-            if (this.get_tare() > 0) {
+            if (this.has_tare) {
                 // This is valid because the tare is stored using product UOM.
                 this.set_quantity(this.get_quantity() + this.get_tare());
                 this.reset_tare();
@@ -92,24 +93,28 @@ const TareOrderline = (Orderline_) =>
             return this.tare;
         }
 
+        get has_tare() {
+            return this.tare > 0;
+        }
+
         get_gross_weight() {
             return this.get_tare() + this.get_quantity();
         }
 
         get_tare_str_with_unit() {
             const unit = this.get_unit();
-            const tare_str = format_tare(this.pos, this.tare, this.get_unit());
-            return tare_str + " " + unit.name;
+            const tare_str = format_quantity(this.pos, this.tare, this.get_unit());
+            return tare_str + " " + unit.name;
         }
 
         get_gross_weight_str_with_unit() {
             const unit = this.get_unit();
-            const gross_weight_str = format_tare(
+            const gross_weight_str = format_quantity(
                 this.pos,
                 this.get_gross_weight(),
                 this.get_unit()
             );
-            return gross_weight_str + " " + unit.name;
+            return gross_weight_str + " " + unit.name;
         }
     };
 

--- a/pos_tare/static/src/js/tools.esm.js
+++ b/pos_tare/static/src/js/tools.esm.js
@@ -34,8 +34,8 @@ export function convert_mass(mass, from_unit, to_unit) {
     return result || 0;
 }
 
-// Format the tare value.
-export function format_tare(pos, qty, unit) {
+// Format a quantity according to its UoM.
+export function format_quantity(pos, qty, unit) {
     if (unit.rounding) {
         const q = round_precision(qty, unit.rounding);
         const decimals = pos.dp["Product Unit of Measure"];

--- a/pos_tare/static/src/xml/Screens/ProductScreen/Orderline.xml
+++ b/pos_tare/static/src/xml/Screens/ProductScreen/Orderline.xml
@@ -8,7 +8,7 @@
         owl="1"
     >
         <xpath expr="//ul[hasclass('info-list')]" operation="inside">
-            <t t-if="props.line.get_tare() !== 0">
+            <t t-if="props.line.has_tare">
                 <li class="info">
                     <i>
                       Gross Weight:

--- a/pos_tare/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
+++ b/pos_tare/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
@@ -8,15 +8,13 @@
         owl="1"
     >
         <xpath expr="//t[@t-if='line.discount !== 0']" position="after">
-            <t t-if="line.tare_quantity > 0">
+            <t t-if="line.has_tare">
                 <div class="pos-receipt-left-padding">
                     Gross Weight:
-                    <t t-out="line.gross_quantity" />
-                    <t t-if="!line.is_in_unit" t-esc="line.unit_name" />
+                    <t t-out="line.gross_weight_str" />
                     <br />
                     Tare:
-                    <t t-out="line.tare_quantity" />
-                    <t t-if="!line.is_in_unit" t-esc="line.unit_name" />
+                    <t t-out="line.tare_str" />
                     <br />
                 </div>
             </t>


### PR DESCRIPTION
*   ensure that the gross and tare weights are formatted correctly on the receipt, according to the uom rounding, the decimal precision and the decimal separator (in the same way as on the order screen).
*   rename `format_tare()` to `format_quantity()`.
*   separate the quantity and the unit name using a non-breaking space to avoid a line wrapping between them.
*   add `has_tare` property to `Orderline`.
*   update and improve fr translation.