### PR TITLE
[16.0][FIX] pos_cash_move_reason empty field

### DIFF
--- a/pos_cash_move_reason/wizard/wizard_pos_move_reason.py
+++ b/pos_cash_move_reason/wizard/wizard_pos_move_reason.py
@@ -88,5 +88,6 @@ class WizardPosMoveReason(models.TransientModel):
             "journal_id": self.journal_id.id,
             "amount": amount,
             "payment_ref": f"{self.session_id.name} - {self.name}",
+            "pos_move_reason": self.move_reason_id.id,
             "counterpart_account_id": account_id,
         }


### PR DESCRIPTION
Trivial fix, wizard creation of pos_cash_move_reason forget pos_move_reason in account_bank_statement_line creation