### PR TITLE
[19.0] checklog: ignore chrome zombie teardown warning

### DIFF
--- a/checklog-odoo.cfg
+++ b/checklog-odoo.cfg
@@ -1,3 +1,4 @@
 [checklog-odoo]
 ignore=
     WARNING.* 0 failed, 0 error\(s\).*
+    WARNING.*Killing chrome descendants-or-self.*


### PR DESCRIPTION
### Problem
Every PR in this repo that runs an HttpCase **tour** (PoS / web frontend tests) currently fails CI even though the tests themselves pass (`0 failed, 0 error(s)`). The build is turned red by `checklog-odoo`, which flags this teardown warning:

```
WARNING ... Killing chrome descendants-or-self of N: M remaining
- chrome (zombie)
```

The headless Chrome used by the tour leaves defunct (zombie) child processes that Odoo force-kills at the end of the test. They are already dead; the warning is purely environmental (CI runner process reaping) and not a defect in any addon.

### Effect
Any migration/feature PR that adds or touches a tour is blocked (e.g. #1576, #1570, #1574 — all green tests, red build on this exact warning), while PRs without tours pass.

### Fix
Add an ignore pattern for this teardown warning to `checklog-odoo.cfg`, consistent with the existing `0 failed, 0 error(s)` ignore entry.