### PR TITLE
[FIX] pos_order_to_sale_order: hook _pre_confirm_from_pos previo a ac…

### DIFF
--- a/pos_order_to_sale_order/models/sale_order.py
+++ b/pos_order_to_sale_order/models/sale_order.py
@@ -47,6 +47,7 @@ class SaleOrder(models.Model):
 
         # Confirm Sale Order
         if action in ["confirmed", "delivered", "invoiced"]:
+            sale_order._pre_confirm_from_pos(order_data)
             sale_order.action_confirm()
 
         # mark picking as delivered
@@ -64,3 +65,9 @@ class SaleOrder(models.Model):
         return {
             "sale_order_id": sale_order.id,
         }
+
+    def _pre_confirm_from_pos(self, order_data):
+        """Hook for extension modules to prepare the order (e.g. carrier or
+        warehouse auto-assignment) before it is confirmed from the POS flow.
+        """
+        return


### PR DESCRIPTION
## Summary

Adds a no-op extension hook, `_pre_confirm_from_pos(order_data)`, called
from `create_order_from_pos` right before `action_confirm()` is invoked
(only when the order is actually going to be confirmed).

Motivation

create_order_from_pos creates, confirms, delivers and invoices the sale
order in a single call, with no seam between "create" and "confirm". Any
downstream module that needs to prepare the order (e.g. auto-assign a
delivery carrier or warehouse) before it is confirmed currently has no
way to do so other than embedding that logic inside its own
action_confirm() override.

That is fragile: if any other module patches action_confirm via
_patch_method (a common pattern for global exception/validation checks),
the patch wraps the already-merged MRO chain and runs before any
_inherit-based override gets a chance to run — including the one doing
the carrier/warehouse assignment. The order can then get stuck without a
carrier and, in a programmatic context like POS order creation, fail to
confirm silently.

This hook gives downstream modules a proper place to run that kind of
preparation logic strictly before action_confirm() is ever invoked from
this flow, without having to touch — or race against — whatever patches
action_confirm itself.

Changes

- pos_order_to_sale_order/models/sale_order.py: new no-op
_pre_confirm_from_pos method, called from create_order_from_pos.

No existing behavior changes — the hook is a no-op unless a downstream
module overrides it.

Testing

- Existing test suite (test_module.py tour, test_sale_order.py) run
unmodified against a fresh test database; no regressions introduced by
this change.
- A downstream module (internal, not part of this PR) exercises the hook
by overriding it to assign a delivery carrier before confirmation, with
its own dedicated unit tests.
