### PR TITLE
[18.0][FIX] pos_order_remove_line: Hide remove button in OrderReceipt

### DIFF
--- a/pos_order_remove_line/static/src/js/orderline.esm.js
+++ b/pos_order_remove_line/static/src/js/orderline.esm.js
@@ -10,6 +10,12 @@ import {patch} from "@web/core/utils/patch";
 import {usePos} from "@point_of_sale/app/store/pos_hook";
 import {useService} from "@web/core/utils/hooks";
 
+patch(Orderline, {
+    props: {
+        ...Orderline.props,
+        isReceipt: {type: Boolean, optional: true},
+    },
+});
 patch(Orderline.prototype, {
     setup() {
         super.setup();
@@ -18,7 +24,7 @@ patch(Orderline.prototype, {
         this.pos = usePos();
     },
     get isDisplayButtonRemove() {
-        return this.pos.config.pos_line_remove_btn;
+        return this.pos.config.pos_line_remove_btn && !this.props.isReceipt;
     },
     _executeRemove() {
         this.numberBuffer.sendKey("Backspace");

--- a/pos_order_remove_line/static/src/xml/orderline.xml
+++ b/pos_order_remove_line/static/src/xml/orderline.xml
@@ -3,7 +3,12 @@
   ~ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
   -->
 <templates id="template" xml:space="preserve">
-  <t t-inherit="point_of_sale.Orderline" t-inherit-mode="extension">
+    <t t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension">
+        <xpath expr="//Orderline" position="attributes">
+            <attribute name="isReceipt">true</attribute>
+        </xpath>
+    </t>
+    <t t-inherit="point_of_sale.Orderline" t-inherit-mode="extension">
         <xpath expr="//div[@t-if='props.showTaxGroupLabels']" position="after">
             <button
                 class="btn remove-line-button"


### PR DESCRIPTION
Hide remove button in OrderReceipt

**Before**
<img width="630" height="755" alt="antes" src="https://github.com/user-attachments/assets/59514f8a-b66e-4fd5-9d8a-756cf640ba31" />

**After**
<img width="621" height="761" alt="despues" src="https://github.com/user-attachments/assets/8192f303-8774-4673-a75b-da62c4aeea07" />

Please @pedrobaeza and @Andrii9090-tecnativa can you review it?

@Tecnativa TT64225