### PR TITLE
[18.0][FIX] pos_user_restriction: wrong partner_id in test_validate_session

### DIFF
--- a/pos_user_restriction/tests/test_hacks.py
+++ b/pos_user_restriction/tests/test_hacks.py
@@ -56,7 +56,7 @@ class TestHacks(TestPoSCommon):
             {
                 "company_id": self.env.company.id,
                 "session_id": session.id,
-                "partner_id": self.env.user.id,
+                "partner_id": self.env.user.partner_id.id,
                 "lines": [
                     (
                         0,


### PR DESCRIPTION
partner_id should be res.partner not res.users record